### PR TITLE
Add reusable identities for stable LAN devices

### DIFF
--- a/flutter/lib/common/widgets/dialog.dart
+++ b/flutter/lib/common/widgets/dialog.dart
@@ -11,6 +11,7 @@ import 'package:flutter_hbb/models/state_model.dart';
 import 'package:get/get.dart';
 
 import '../../common.dart';
+import '../../desktop/lan_identity_manager.dart';
 import '../../models/model.dart';
 import '../../models/platform_model.dart';
 
@@ -307,6 +308,10 @@ _connectDialog(
   final errUsername = ''.obs;
   final errPassword = ''.obs;
   bool rememberPassword = false;
+  final List<LanIdentityProfile> lanIdentities = lanAccess && isDesktop
+      ? loadLanIdentityProfiles()
+      : const [];
+  var selectedIdentityId = lanIdentityManualValue;
   if (osUsernameController != null) {
     osUsernameController.addListener(() {
       if (errUsername.value.isNotEmpty) {
@@ -317,13 +322,16 @@ _connectDialog(
 
   dialogManager.dismissAll();
   dialogManager.show((setState, close, context) {
+    final usingLanIdentity =
+        lanAccess && selectedIdentityId != lanIdentityManualValue;
+
     cancel() {
       close();
       closeConnection();
     }
 
     submit() {
-      if (osUsernameController != null) {
+      if (osUsernameController != null && !usingLanIdentity) {
         if (osUsernameController.text.trim().isEmpty) {
           errUsername.value = translate('Empty Username');
           setState(() {});
@@ -334,11 +342,22 @@ _connectDialog(
       final osPassword = osPasswordController?.text ?? '';
       final password = passwordController?.text.trim() ?? '';
       if (lanAccess) {
-        if (osPassword.isEmpty) {
-          errPassword.value = translate('Empty Password');
+        if (usingLanIdentity) {
+          final error = bind.sessionLoginLanIdentity(
+            sessionId: sessionId,
+            identityId: selectedIdentityId,
+            bindOnSuccess: rememberPassword,
+          );
+          if (error.isNotEmpty) {
+            errPassword.value = error;
           setState(() {});
           return;
         }
+        } else if (osPassword.isEmpty) {
+          errPassword.value = translate('Empty Password');
+          setState(() {});
+          return;
+        } else {
         final error = bind.sessionLoginLan(
           sessionId: sessionId,
           username: osUsername,
@@ -350,6 +369,7 @@ _connectDialog(
           errPassword.value = error;
           setState(() {});
           return;
+        }
         }
       } else {
         if (passwordController != null && password.isEmpty) return;
@@ -444,7 +464,37 @@ _connectDialog(
       content: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          osAccountWidget(),
+          if (lanAccess && isDesktop && lanIdentities.isNotEmpty)
+            DropdownButtonFormField<String>(
+              key: ValueKey(selectedIdentityId),
+              initialValue: selectedIdentityId,
+              decoration: InputDecoration(
+                labelText: translate('Account'),
+                prefixIcon: const Icon(Icons.badge_outlined),
+              ),
+              items: [
+                DropdownMenuItem(
+                  value: lanIdentityManualValue,
+                  child: Text(
+                    '${translate('Username')} · ${translate('Password')}',
+                  ),
+                ),
+                ...lanIdentities.map(
+                  (identity) => DropdownMenuItem(
+                    value: identity.id,
+                    child: Text(
+                      identity.isDefault
+                          ? '${identity.name} (${translate('Default')})'
+                          : identity.name,
+                    ),
+                  ),
+                ),
+              ],
+              onChanged: (value) => setState(
+                () => selectedIdentityId = value ?? lanIdentityManualValue,
+              ),
+            ).paddingOnly(bottom: 12),
+          if (!usingLanIdentity) osAccountWidget(),
           osUsernameController == null || passwordController == null
               ? Offstage()
               : Container(height: 12),
@@ -457,7 +507,11 @@ _connectDialog(
               contentPadding: EdgeInsets.zero,
               dense: true,
               controlAffinity: ListTileControlAffinity.leading,
-              title: Text(translate('Remember password')),
+              title: Text(
+                usingLanIdentity
+                    ? '${translate('Remember password')} · ${translate('Account')}'
+                    : translate('Remember password'),
+              ),
             ),
         ],
       ),

--- a/flutter/lib/common/widgets/peer_card.dart
+++ b/flutter/lib/common/widgets/peer_card.dart
@@ -9,14 +9,15 @@ import 'package:provider/provider.dart';
 
 import '../../common.dart';
 import '../../common/formatter/id_formatter.dart';
+import '../../desktop/lan_identity_manager.dart';
 import '../../models/peer_model.dart';
 import '../../models/platform_model.dart';
 import '../../desktop/widgets/material_mod_popup_menu.dart' as mod_menu;
 import '../../desktop/widgets/popup_menu.dart';
 import 'responsive_layout.dart';
 
-typedef PopupMenuEntryBuilder = Future<List<mod_menu.PopupMenuEntry<String>>>
-    Function(BuildContext);
+typedef PopupMenuEntryBuilder =
+    Future<List<mod_menu.PopupMenuEntry<String>>> Function(BuildContext);
 
 enum PeerUiType { grid, tile, list }
 
@@ -103,20 +104,25 @@ class _PeerCardState extends State<_PeerCard>
           ? peer.hostname
           : '${peer.username}${peer.username.isNotEmpty && peer.hostname.isNotEmpty ? '@' : ''}${peer.hostname}';
     }
-    return [peer.platform, formatID(peer.id)]
-        .where((value) => value.isNotEmpty)
-        .join(' · ');
+    return [
+      peer.platform,
+      formatID(peer.id),
+    ].where((value) => value.isNotEmpty).join(' · ');
   }
 
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    return Obx(() => shouldUseCompactPeerLayout(
+    return Obx(
+      () =>
+          shouldUseCompactPeerLayout(
             isMobilePlatform: isMobile,
             isWebMobile: isWeb && !isWebDesktop,
-            isPortrait: stateGlobal.isPortrait.isTrue)
+            isPortrait: stateGlobal.isPortrait.isTrue,
+          )
         ? _buildPortrait()
-        : _buildLandscape());
+          : _buildLandscape(),
+    );
   }
 
   Widget gestureDetector({required Widget child}) {
@@ -365,8 +371,9 @@ class _PeerCardState extends State<_PeerCard>
                               borderRadius: BorderRadius.circular(7),
                               boxShadow: [
                                 BoxShadow(
-                                  color:
-                                      const Color(0xFF1677FF).withOpacity(0.25),
+                                  color: const Color(
+                                    0xFF1677FF,
+                                  ).withOpacity(0.25),
                                   blurRadius: 14,
                                   offset: const Offset(0, 7),
                                 ),
@@ -384,10 +391,7 @@ class _PeerCardState extends State<_PeerCard>
                   Row(
                     children: [
                       getOnline(8, peer.online),
-                      Text(
-                        'LAN',
-                        style: TextStyle(fontSize: 12, color: muted),
-                      ),
+                      Text('LAN', style: TextStyle(fontSize: 12, color: muted)),
                       const Spacer(),
                       IconButton(
                         tooltip: _favorite
@@ -615,8 +619,7 @@ abstract class BasePeerCard extends StatelessWidget {
 
   Future<List<mod_menu.PopupMenuEntry<String>>> _buildPopupMenuEntry(
     BuildContext context,
-  ) async =>
-      (await _buildMenuItems(context))
+  ) async => (await _buildMenuItems(context))
           .map(
             (e) => e.build(
               context,
@@ -673,6 +676,85 @@ abstract class BasePeerCard extends StatelessWidget {
           ? translate('Connect')
           : '${translate('Connect')} ${peer.id}'),
     );
+  }
+
+  Future<List<MenuEntryBase<String>>> _lanIdentityActions(
+    BuildContext context,
+  ) async {
+    if (!isDesktop) return const [];
+    final actions = <MenuEntryBase<String>>[
+      MenuEntryButton<String>(
+        childBuilder: (TextStyle? style) => Text(
+          '${translate('Connect')} · ${translate('Account')}',
+          style: style,
+        ),
+        proc: () {
+          () async {
+            final identityId = await showLanIdentityPicker(
+              context,
+              fingerprint: peer.fingerprint,
+            );
+            if (identityId == null || !context.mounted) return;
+            connectInPeerTab(context, peer, tab, identityId: identityId);
+          }();
+        },
+        padding: menuPadding,
+        dismissOnClicked: true,
+      ),
+    ];
+
+    if (peer.fingerprint.isEmpty) return actions;
+    final boundIdentityId = bind.mainGetBoundLanIdentityId(
+      fingerprint: peer.fingerprint,
+    );
+    if (boundIdentityId.isNotEmpty) {
+      actions.add(
+        MenuEntryButton<String>(
+          childBuilder: (TextStyle? style) => Text(
+            '${translate('Remove')} · ${translate('Account')}',
+            style: style,
+          ),
+          proc: () {
+            final error = bind.mainBindLanIdentity(
+              fingerprint: peer.fingerprint,
+              identityId: '',
+            );
+            showToast(error.isEmpty ? translate('Successful') : error);
+          },
+          padding: menuPadding,
+          dismissOnClicked: true,
+        ),
+      );
+    }
+    if (bind.mainHasLegacyLanCredential(fingerprint: peer.fingerprint)) {
+      actions.add(
+        MenuEntryButton<String>(
+          childBuilder: (TextStyle? style) => Text(
+            '${translate('Add')} · ${translate('Account')}',
+            style: style,
+          ),
+          proc: () {
+            () async {
+              final identityId = await showImportLegacyLanCredentialDialog(
+                context,
+                fingerprint: peer.fingerprint,
+                suggestedName: peer.alias.isNotEmpty
+                    ? peer.alias
+                    : peer.hostname.isNotEmpty
+                    ? peer.hostname
+                    : peer.id,
+              );
+              if (identityId != null) {
+                showToast(translate('Successful'));
+              }
+            }();
+          },
+          padding: menuPadding,
+          dismissOnClicked: true,
+        ),
+      );
+    }
+    return actions;
   }
 
   @protected
@@ -985,6 +1067,7 @@ class RecentPeerCard extends BasePeerCard {
       _viewCameraAction(context),
       _terminalAction(context),
     ];
+    menuItems.addAll(await _lanIdentityActions(context));
 
     if (peer.platform == kPeerPlatformWindows) {
       menuItems.add(_terminalRunAsAdminAction(context));
@@ -1041,6 +1124,7 @@ class FavoritePeerCard extends BasePeerCard {
       _viewCameraAction(context),
       _terminalAction(context),
     ];
+    menuItems.addAll(await _lanIdentityActions(context));
 
     if (peer.platform == kPeerPlatformWindows) {
       menuItems.add(_terminalRunAsAdminAction(context));
@@ -1095,6 +1179,7 @@ class DiscoveredPeerCard extends BasePeerCard {
       _viewCameraAction(context),
       _terminalAction(context),
     ];
+    menuItems.addAll(await _lanIdentityActions(context));
 
     if (peer.platform == kPeerPlatformWindows) {
       menuItems.add(_terminalRunAsAdminAction(context));
@@ -1320,11 +1405,14 @@ void connectInPeerTab(
   bool isTcpTunneling = false,
   bool isRDP = false,
   bool isTerminal = false,
+  String? identityId,
 }) async {
   connect(
     context,
     peer.id,
-    password: '',
+    password: identityId == null
+        ? ''
+        : buildLanIdentityPayload(identityId, bindIdentity: true),
     username: peer.username,
     isFileTransfer: isFileTransfer,
     isTerminal: isTerminal,

--- a/flutter/lib/desktop/lan_identity_manager.dart
+++ b/flutter/lib/desktop/lan_identity_manager.dart
@@ -1,0 +1,485 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+
+import '../common.dart';
+import '../models/platform_model.dart';
+
+const String lanIdentityManualValue = '__manual__';
+
+class LanIdentityProfile {
+  final String id;
+  final String name;
+  final String username;
+  final bool isDefault;
+
+  const LanIdentityProfile({
+    required this.id,
+    required this.name,
+    required this.username,
+    required this.isDefault,
+  });
+
+  factory LanIdentityProfile.fromJson(Map<String, dynamic> json) {
+    return LanIdentityProfile(
+      id: json['id']?.toString() ?? '',
+      name: json['name']?.toString() ?? '',
+      username: json['username']?.toString() ?? '',
+      isDefault: json['is_default'] == true,
+    );
+  }
+}
+
+List<LanIdentityProfile> loadLanIdentityProfiles() {
+  try {
+    final decoded = jsonDecode(bind.mainListLanIdentities());
+    if (decoded is! List) return const [];
+    return decoded
+        .whereType<Map<String, dynamic>>()
+        .map(LanIdentityProfile.fromJson)
+        .where((identity) => identity.id.isNotEmpty)
+        .toList();
+  } catch (error) {
+    debugPrint('Failed to load LAN identities: $error');
+    return const [];
+  }
+}
+
+String? defaultLanIdentityId(List<LanIdentityProfile> identities) {
+  for (final identity in identities) {
+    if (identity.isDefault) return identity.id;
+  }
+  return null;
+}
+
+String buildLanIdentityPayload(String identityId, {bool bindIdentity = false}) {
+  return jsonEncode({
+    'lan_version': 1,
+    'identity_id': identityId,
+    'bind_identity': bindIdentity,
+  });
+}
+
+Future<String?> showLanIdentityEditor(
+  BuildContext context, {
+  LanIdentityProfile? identity,
+}) async {
+  final nameController = TextEditingController(text: identity?.name ?? '');
+  final usernameController = TextEditingController(
+    text: identity?.username ?? '',
+  );
+  final passwordController = TextEditingController();
+  var makeDefault = identity?.isDefault ?? false;
+  var saving = false;
+  var errorText = '';
+
+  final result = await showDialog<String>(
+    context: context,
+    builder: (dialogContext) => StatefulBuilder(
+      builder: (context, setState) {
+        Future<void> save() async {
+          if (saving) return;
+          setState(() {
+            saving = true;
+            errorText = '';
+          });
+
+          if (identity == null) {
+            final response =
+                jsonDecode(
+                      bind.mainCreateLanIdentity(
+                        name: nameController.text,
+                        username: usernameController.text,
+                        password: passwordController.text,
+                        makeDefault: makeDefault,
+                      ),
+                    )
+                    as Map<String, dynamic>;
+            passwordController.clear();
+            final error = response['error']?.toString() ?? '';
+            final identityId = response['identity_id']?.toString() ?? '';
+            if (error.isEmpty && identityId.isNotEmpty) {
+              if (dialogContext.mounted) {
+                Navigator.of(dialogContext).pop(identityId);
+              }
+              return;
+            }
+            errorText = error.isEmpty ? translate('Failed') : error;
+          } else {
+            final error = bind.mainUpdateLanIdentity(
+              identityId: identity.id,
+              name: nameController.text,
+              username: usernameController.text,
+              password: passwordController.text,
+              makeDefault: makeDefault,
+            );
+            passwordController.clear();
+            if (error.isEmpty) {
+              if (dialogContext.mounted) {
+                Navigator.of(dialogContext).pop(identity.id);
+              }
+              return;
+            }
+            errorText = error;
+          }
+          if (dialogContext.mounted) {
+            setState(() => saving = false);
+          }
+        }
+
+        return AlertDialog(
+          title: Text(
+            '${translate(identity == null ? 'Add' : 'Edit')} ${translate('Account')}',
+          ),
+          content: SizedBox(
+            width: 420,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextField(
+                  controller: nameController,
+                  autofocus: true,
+                  decoration: InputDecoration(
+                    labelText: translate('Name'),
+                    prefixIcon: const Icon(Icons.badge_outlined),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: usernameController,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  decoration: InputDecoration(
+                    labelText: translate('Username'),
+                    prefixIcon: const Icon(Icons.person_outline),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: passwordController,
+                  obscureText: true,
+                  autocorrect: false,
+                  enableSuggestions: false,
+                  decoration: InputDecoration(
+                    labelText: translate('Password'),
+                    helperText: identity == null
+                        ? null
+                        : translate('Leave blank to keep current password'),
+                    prefixIcon: const Icon(Icons.lock_outline),
+                  ),
+                  onSubmitted: (_) => save(),
+                ),
+                CheckboxListTile(
+                  value: makeDefault,
+                  onChanged: saving
+                      ? null
+                      : (value) => setState(() => makeDefault = value == true),
+                  contentPadding: EdgeInsets.zero,
+                  dense: true,
+                  controlAffinity: ListTileControlAffinity.leading,
+                  title: Text(
+                    '${translate('Default')} ${translate('Account')}',
+                  ),
+                ),
+                if (errorText.isNotEmpty)
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      errorText,
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.error,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: saving
+                  ? null
+                  : () => Navigator.of(dialogContext).pop(),
+              child: Text(translate('Cancel')),
+            ),
+            ElevatedButton(
+              onPressed: saving ? null : save,
+              child: saving
+                  ? const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : Text(translate('OK')),
+            ),
+          ],
+        );
+      },
+    ),
+  );
+
+  nameController.dispose();
+  usernameController.dispose();
+  passwordController.dispose();
+  return result;
+}
+
+Future<void> showLanIdentityManager(BuildContext context) async {
+  var identities = loadLanIdentityProfiles();
+
+  await showDialog<void>(
+    context: context,
+    builder: (dialogContext) => StatefulBuilder(
+      builder: (context, setState) {
+        void reload() {
+          setState(() => identities = loadLanIdentityProfiles());
+        }
+
+        Future<void> addIdentity() async {
+          final identityId = await showLanIdentityEditor(context);
+          if (identityId != null) reload();
+        }
+
+        Future<void> editIdentity(LanIdentityProfile identity) async {
+          final identityId = await showLanIdentityEditor(
+            context,
+            identity: identity,
+          );
+          if (identityId != null) reload();
+        }
+
+        Future<void> deleteIdentity(LanIdentityProfile identity) async {
+          final confirmed =
+              await showDialog<bool>(
+                context: context,
+                builder: (confirmContext) => AlertDialog(
+                  title: Text(translate('Delete')),
+                  content: Text('${translate('Delete')} “${identity.name}”?'),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.of(confirmContext).pop(false),
+                      child: Text(translate('Cancel')),
+                    ),
+                    ElevatedButton(
+                      onPressed: () => Navigator.of(confirmContext).pop(true),
+                      child: Text(translate('Delete')),
+                    ),
+                  ],
+                ),
+              ) ??
+              false;
+          if (!confirmed) return;
+          final error = bind.mainDeleteLanIdentity(identityId: identity.id);
+          if (error.isNotEmpty) {
+            showToast(error);
+            return;
+          }
+          reload();
+        }
+
+        Future<void> setDefault(LanIdentityProfile identity) async {
+          final error = bind.mainSetDefaultLanIdentity(identityId: identity.id);
+          if (error.isNotEmpty) {
+            showToast(error);
+            return;
+          }
+          reload();
+        }
+
+        return AlertDialog(
+          title: Text('${translate('Account')} · ${translate('Settings')}'),
+          content: SizedBox(
+            width: 540,
+            height: 360,
+            child: identities.isEmpty
+                ? Center(child: Text(translate('No existing sessions')))
+                : ListView.separated(
+                    itemCount: identities.length,
+                    separatorBuilder: (_, __) => const Divider(height: 1),
+                    itemBuilder: (context, index) {
+                      final identity = identities[index];
+                      return ListTile(
+                        leading: CircleAvatar(
+                          child: Icon(
+                            identity.isDefault
+                                ? Icons.star_rounded
+                                : Icons.person_outline,
+                          ),
+                        ),
+                        title: Text(identity.name),
+                        subtitle: Text(identity.username),
+                        trailing: Wrap(
+                          spacing: 2,
+                          children: [
+                            IconButton(
+                              tooltip: translate('Default'),
+                              onPressed: identity.isDefault
+                                  ? null
+                                  : () => setDefault(identity),
+                              icon: const Icon(Icons.star_outline_rounded),
+                            ),
+                            IconButton(
+                              tooltip: translate('Edit'),
+                              onPressed: () => editIdentity(identity),
+                              icon: const Icon(Icons.edit_outlined),
+                            ),
+                            IconButton(
+                              tooltip: translate('Delete'),
+                              onPressed: () => deleteIdentity(identity),
+                              icon: const Icon(Icons.delete_outline),
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                  ),
+          ),
+          actions: [
+            TextButton.icon(
+              onPressed: addIdentity,
+              icon: const Icon(Icons.add),
+              label: Text(translate('Add')),
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: Text(translate('Close')),
+            ),
+          ],
+        );
+      },
+    ),
+  );
+}
+
+Future<String?> showLanIdentityPicker(
+  BuildContext context, {
+  String fingerprint = '',
+}) async {
+  var identities = loadLanIdentityProfiles();
+  if (identities.isEmpty) {
+    final created = await showLanIdentityEditor(context);
+    return created;
+  }
+  final boundIdentityId = fingerprint.isEmpty
+      ? ''
+      : bind.mainGetBoundLanIdentityId(fingerprint: fingerprint);
+
+  return showDialog<String>(
+    context: context,
+    builder: (dialogContext) => AlertDialog(
+      title: Text(translate('Account')),
+      content: SizedBox(
+        width: 420,
+        child: ListView(
+          shrinkWrap: true,
+          children: identities
+              .map(
+                (identity) => ListTile(
+                  leading: Icon(
+                    identity.id == boundIdentityId
+                        ? Icons.link_rounded
+                        : identity.isDefault
+                        ? Icons.star_rounded
+                        : Icons.person_outline,
+                  ),
+                  title: Text(identity.name),
+                  subtitle: Text(identity.username),
+                  onTap: () => Navigator.of(dialogContext).pop(identity.id),
+                ),
+              )
+              .toList(),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () async {
+            await showLanIdentityManager(context);
+            identities = loadLanIdentityProfiles();
+            if (dialogContext.mounted) {
+              Navigator.of(dialogContext).pop();
+            }
+          },
+          child: Text(translate('Settings')),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(dialogContext).pop(),
+          child: Text(translate('Cancel')),
+        ),
+      ],
+    ),
+  );
+}
+
+Future<String?> showImportLegacyLanCredentialDialog(
+  BuildContext context, {
+  required String fingerprint,
+  required String suggestedName,
+}) async {
+  final nameController = TextEditingController(text: suggestedName);
+  var makeDefault = false;
+  var errorText = '';
+  final identityId = await showDialog<String>(
+    context: context,
+    builder: (dialogContext) => StatefulBuilder(
+      builder: (context, setState) => AlertDialog(
+        title: Text('${translate('Add')} ${translate('Account')}'),
+        content: SizedBox(
+          width: 420,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: nameController,
+                autofocus: true,
+                decoration: InputDecoration(labelText: translate('Name')),
+              ),
+              CheckboxListTile(
+                value: makeDefault,
+                onChanged: (value) =>
+                    setState(() => makeDefault = value == true),
+                contentPadding: EdgeInsets.zero,
+                controlAffinity: ListTileControlAffinity.leading,
+                title: Text('${translate('Default')} ${translate('Account')}'),
+              ),
+              if (errorText.isNotEmpty)
+                Text(
+                  errorText,
+                  style: TextStyle(color: Theme.of(context).colorScheme.error),
+                ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: Text(translate('Cancel')),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              final response =
+                  jsonDecode(
+                        bind.mainImportLegacyLanCredential(
+                          fingerprint: fingerprint,
+                          name: nameController.text,
+                          makeDefault: makeDefault,
+                        ),
+                      )
+                      as Map<String, dynamic>;
+              final error = response['error']?.toString() ?? '';
+              final importedId = response['identity_id']?.toString() ?? '';
+              if (error.isEmpty && importedId.isNotEmpty) {
+                Navigator.of(dialogContext).pop(importedId);
+              } else {
+                setState(() {
+                  errorText = error.isEmpty ? translate('Failed') : error;
+                });
+              }
+            },
+            child: Text(translate('OK')),
+          ),
+        ],
+      ),
+    ),
+  );
+  nameController.dispose();
+  return identityId;
+}

--- a/flutter/lib/desktop/pages/connection_page.dart
+++ b/flutter/lib/desktop/pages/connection_page.dart
@@ -17,6 +17,7 @@ import '../../common.dart';
 import '../../common/formatter/id_formatter.dart';
 import '../../common/widgets/peer_tab_page.dart';
 import '../../models/platform_model.dart';
+import '../lan_identity_manager.dart';
 
 class OnlineStatusWidget extends StatefulWidget {
   const OnlineStatusWidget({Key? key, this.onSvcStatusChanged})
@@ -61,8 +62,7 @@ class _OnlineStatusWidgetState extends State<OnlineStatusWidget> {
             },
             child: Text(
               translate("Start service"),
-              style:
-                  TextStyle(decoration: TextDecoration.underline, fontSize: em),
+          style: TextStyle(decoration: TextDecoration.underline, fontSize: em),
             ),
           ).marginOnly(left: em),
         );
@@ -75,7 +75,8 @@ class _OnlineStatusWidgetState extends State<OnlineStatusWidget> {
               width: 8,
               decoration: BoxDecoration(
                 borderRadius: BorderRadius.circular(4),
-                color: _svcStopped.value ||
+            color:
+                _svcStopped.value ||
                         stateGlobal.svcStatus.value == SvcStatus.connecting
                     ? kColorWarn
                     : (stateGlobal.svcStatus.value == SvcStatus.ready
@@ -145,10 +146,8 @@ class _OnlineStatusWidgetState extends State<OnlineStatusWidget> {
 
 /// Connection page for connecting to a remote peer.
 class ConnectionPage extends StatefulWidget {
-  const ConnectionPage({
-    Key? key,
-    this.selectedPeerTab = PeerTabIndex.lan,
-  }) : super(key: key);
+  const ConnectionPage({Key? key, this.selectedPeerTab = PeerTabIndex.lan})
+    : super(key: key);
 
   final PeerTabIndex selectedPeerTab;
 
@@ -166,6 +165,7 @@ class _ConnectionPageState extends State<ConnectionPage> with WindowListener {
   final TextEditingController _usernameController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
   bool _rememberPassword = false;
+  List<LanIdentityProfile> _lanIdentities = const [];
   Timer? _lanDiscoveryTimer;
 
   bool isWindowMinimized = false;
@@ -173,8 +173,9 @@ class _ConnectionPageState extends State<ConnectionPage> with WindowListener {
   @override
   void initState() {
     super.initState();
-    final savedCardUiType =
-        bind.getLocalFlutterOption(k: kOptionPeerCardUiType);
+    final savedCardUiType = bind.getLocalFlutterOption(
+      k: kOptionPeerCardUiType,
+    );
     if (savedCardUiType == PeerUiType.list.name) {
       peerCardUiType.value = PeerUiType.list;
     } else {
@@ -195,6 +196,7 @@ class _ConnectionPageState extends State<ConnectionPage> with WindowListener {
     Get.put<TextEditingController>(_idEditingController);
     Get.put<IDTextEditingController>(_idController);
     windowManager.addListener(this);
+    _reloadLanIdentities();
     _loadSelectedPeers();
     _lanDiscoveryTimer = Timer.periodic(lanDiscoveryRefreshInterval, (_) {
       if (shouldRefreshLanDiscovery(
@@ -229,6 +231,10 @@ class _ConnectionPageState extends State<ConnectionPage> with WindowListener {
         bind.mainDiscover();
         break;
     }
+  }
+
+  void _reloadLanIdentities() {
+    _lanIdentities = loadLanIdentityProfiles();
   }
 
   @override
@@ -321,6 +327,26 @@ class _ConnectionPageState extends State<ConnectionPage> with WindowListener {
           child: Row(
             children: [
               const Spacer(),
+              OutlinedButton.icon(
+                onPressed: () async {
+                  await showLanIdentityManager(context);
+                  if (mounted) {
+                    setState(_reloadLanIdentities);
+                  }
+                },
+                icon: const Icon(Icons.badge_outlined, size: 20),
+                label: Text(translate('Account')),
+                style: OutlinedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 13,
+                  ),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
               ElevatedButton.icon(
                 onPressed: () => _showAddDeviceDialog(context),
                 icon: const Icon(Icons.add, size: 20),
@@ -497,10 +523,53 @@ class _ConnectionPageState extends State<ConnectionPage> with WindowListener {
   }
 
   Future<void> _showAddDeviceDialog(BuildContext context) async {
+    _reloadLanIdentities();
+    var selectedIdentityId =
+        defaultLanIdentityId(_lanIdentities) ?? lanIdentityManualValue;
+    var bindIdentity = true;
+
     await showDialog<void>(
       context: context,
       builder: (dialogContext) => StatefulBuilder(
-        builder: (context, setDialogState) => AlertDialog(
+        builder: (context, setDialogState) {
+          final usingIdentity = selectedIdentityId != lanIdentityManualValue;
+
+          Future<void> connectNow() async {
+            final connected = await onConnect(
+              identityId: usingIdentity ? selectedIdentityId : null,
+              bindIdentity: usingIdentity && bindIdentity,
+            );
+            if (connected && dialogContext.mounted) {
+              Navigator.of(dialogContext).pop();
+            }
+          }
+
+          Future<void> manageIdentities() async {
+            await showLanIdentityManager(context);
+            _reloadLanIdentities();
+            if (!_lanIdentities.any(
+              (identity) => identity.id == selectedIdentityId,
+            )) {
+              selectedIdentityId =
+                  defaultLanIdentityId(_lanIdentities) ??
+                  lanIdentityManualValue;
+            }
+            if (dialogContext.mounted) {
+              setDialogState(() {});
+            }
+          }
+
+          Future<void> createIdentity() async {
+            final identityId = await showLanIdentityEditor(context);
+            if (identityId == null) return;
+            _reloadLanIdentities();
+            selectedIdentityId = identityId;
+            if (dialogContext.mounted) {
+              setDialogState(() {});
+            }
+          }
+
+          return AlertDialog(
           title: Text(translate('Add')),
           content: SizedBox(
             width: 440,
@@ -517,14 +586,58 @@ class _ConnectionPageState extends State<ConnectionPage> with WindowListener {
                     prefixIcon: const Icon(Icons.desktop_windows_outlined),
                   ),
                   onChanged: (value) => _idController.id = value,
-                  onSubmitted: (_) async {
-                    final connected = await onConnect();
-                    if (connected && dialogContext.mounted) {
-                      Navigator.of(dialogContext).pop();
-                    }
-                  },
+                    onSubmitted: (_) => connectNow(),
                 ),
                 const SizedBox(height: 12),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: DropdownButtonFormField<String>(
+                          key: ValueKey(selectedIdentityId),
+                          initialValue: selectedIdentityId,
+                          decoration: InputDecoration(
+                            labelText: translate('Account'),
+                            prefixIcon: const Icon(Icons.badge_outlined),
+                          ),
+                          items: [
+                            DropdownMenuItem(
+                              value: lanIdentityManualValue,
+                              child: Text(
+                                '${translate('Username')} · ${translate('Password')}',
+                              ),
+                            ),
+                            ..._lanIdentities.map(
+                              (identity) => DropdownMenuItem(
+                                value: identity.id,
+                                child: Text(
+                                  identity.isDefault
+                                      ? '${identity.name} (${translate('Default')})'
+                                      : identity.name,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
+                            ),
+                          ],
+                          onChanged: (value) => setDialogState(
+                            () => selectedIdentityId =
+                                value ?? lanIdentityManualValue,
+                          ),
+                        ),
+                      ),
+                      IconButton(
+                        tooltip: translate('Add'),
+                        onPressed: createIdentity,
+                        icon: const Icon(Icons.person_add_alt_1_outlined),
+                      ),
+                      IconButton(
+                        tooltip: translate('Settings'),
+                        onPressed: manageIdentities,
+                        icon: const Icon(Icons.settings_outlined),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  if (!usingIdentity) ...[
                 TextField(
                   controller: _usernameController,
                   autocorrect: false,
@@ -544,12 +657,7 @@ class _ConnectionPageState extends State<ConnectionPage> with WindowListener {
                     labelText: translate('Password'),
                     prefixIcon: const Icon(Icons.lock_outline),
                   ),
-                  onSubmitted: (_) async {
-                    final connected = await onConnect();
-                    if (connected && dialogContext.mounted) {
-                      Navigator.of(dialogContext).pop();
-                    }
-                  },
+                      onSubmitted: (_) => connectNow(),
                 ),
                 CheckboxListTile(
                   value: _rememberPassword,
@@ -561,6 +669,18 @@ class _ConnectionPageState extends State<ConnectionPage> with WindowListener {
                   controlAffinity: ListTileControlAffinity.leading,
                   title: Text(translate('Remember password')),
                 ),
+                  ] else
+                    CheckboxListTile(
+                      value: bindIdentity,
+                      onChanged: (value) =>
+                          setDialogState(() => bindIdentity = value == true),
+                      contentPadding: EdgeInsets.zero,
+                      dense: true,
+                      controlAffinity: ListTileControlAffinity.leading,
+                      title: Text(
+                        '${translate('Remember password')} · ${translate('Account')}',
+                      ),
+                    ),
               ],
             ),
           ),
@@ -570,16 +690,12 @@ class _ConnectionPageState extends State<ConnectionPage> with WindowListener {
               child: Text(translate('Cancel')),
             ),
             ElevatedButton(
-              onPressed: () async {
-                final connected = await onConnect();
-                if (connected && dialogContext.mounted) {
-                  Navigator.of(dialogContext).pop();
-                }
-              },
+                onPressed: connectNow,
               child: Text(translate('Connect')),
             ),
           ],
-        ),
+          );
+        },
       ),
     );
   }
@@ -590,17 +706,22 @@ class _ConnectionPageState extends State<ConnectionPage> with WindowListener {
     bool isFileTransfer = false,
     bool isViewCamera = false,
     bool isTerminal = false,
+    String? identityId,
+    bool bindIdentity = false,
   }) async {
     final endpoint = _idController.id;
     final username = _usernameController.text.trim();
     final password = _passwordController.text;
-    if (endpoint.isEmpty || (username.isEmpty && password.isNotEmpty)) {
+    if (endpoint.isEmpty ||
+        (identityId == null && username.isEmpty && password.isNotEmpty)) {
       showToast(
         '${translate('Local Address')} · ${translate('Username')} · ${translate('Password')}',
       );
       return false;
     }
-    final credentialPayload = password.isEmpty
+    final credentialPayload = identityId != null
+        ? buildLanIdentityPayload(identityId, bindIdentity: bindIdentity)
+        : password.isEmpty
         ? null
         : jsonEncode({
             'lan_version': 1,

--- a/flutter/lib/web/bridge.dart
+++ b/flutter/lib/web/bridge.dart
@@ -145,6 +145,23 @@ class RustdeskImpl {
         ]));
   }
 
+  String sessionLoginLan(
+      {required UuidValue sessionId,
+      required String username,
+      required String password,
+      required bool remember,
+      dynamic hint}) {
+    return 'LAN access credentials are not supported in the web client';
+  }
+
+  String sessionLoginLanIdentity(
+      {required UuidValue sessionId,
+      required String identityId,
+      required bool bindOnSuccess,
+      dynamic hint}) {
+    return 'LAN identities are not supported in the web client';
+  }
+
   Future<void> sessionSend2Fa(
       {required UuidValue sessionId,
       required String code,
@@ -839,6 +856,69 @@ class RustdeskImpl {
 
   Future<String> mainGetLanPeers({dynamic hint}) {
     throw UnimplementedError("mainGetLanPeers");
+  }
+
+  String mainListLanIdentities({dynamic hint}) {
+    return '[]';
+  }
+
+  String mainCreateLanIdentity(
+      {required String name,
+      required String username,
+      required String password,
+      required bool makeDefault,
+      dynamic hint}) {
+    return jsonEncode({
+      'identity_id': '',
+      'error': 'LAN identities are not supported in the web client',
+    });
+  }
+
+  String mainUpdateLanIdentity(
+      {required String identityId,
+      required String name,
+      required String username,
+      required String password,
+      required bool makeDefault,
+      dynamic hint}) {
+    return 'LAN identities are not supported in the web client';
+  }
+
+  String mainDeleteLanIdentity({required String identityId, dynamic hint}) {
+    return 'LAN identities are not supported in the web client';
+  }
+
+  String mainSetDefaultLanIdentity(
+      {required String identityId, dynamic hint}) {
+    return 'LAN identities are not supported in the web client';
+  }
+
+  String mainBindLanIdentity(
+      {required String fingerprint,
+      required String identityId,
+      dynamic hint}) {
+    return 'LAN identities are not supported in the web client';
+  }
+
+  String mainGetBoundLanIdentityId(
+      {required String fingerprint, dynamic hint}) {
+    return '';
+  }
+
+  bool mainHasLegacyLanCredential(
+      {required String fingerprint, dynamic hint}) {
+    return false;
+  }
+
+  String mainImportLegacyLanCredential(
+      {required String fingerprint,
+      required String name,
+      required bool makeDefault,
+      dynamic hint}) {
+    return jsonEncode({
+      'identity_id': '',
+      'error': 'LAN identities are not supported in the web client',
+    });
   }
 
   Future<String> mainGetConnectStatus({dynamic hint}) {

--- a/flutter/test/lan_identity_manager_test.dart
+++ b/flutter/test/lan_identity_manager_test.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+
+import 'package:flutter_hbb/desktop/lan_identity_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('LAN identity profiles', () {
+    test('parses metadata without a password field', () {
+      final identity = LanIdentityProfile.fromJson({
+        'id': 'identity-id',
+        'name': 'Operations',
+        'username': 'operator',
+        'is_default': true,
+        'password': 'must-not-be-used',
+      });
+
+      expect(identity.id, 'identity-id');
+      expect(identity.name, 'Operations');
+      expect(identity.username, 'operator');
+      expect(identity.isDefault, isTrue);
+    });
+
+    test('finds the default identity', () {
+      const identities = [
+        LanIdentityProfile(
+          id: 'first',
+          name: 'First',
+          username: 'first-user',
+          isDefault: false,
+        ),
+        LanIdentityProfile(
+          id: 'default',
+          name: 'Default',
+          username: 'operator',
+          isDefault: true,
+        ),
+      ];
+
+      expect(defaultLanIdentityId(identities), 'default');
+      expect(defaultLanIdentityId(const []), isNull);
+    });
+
+    test('connection payload contains only identity selection metadata', () {
+      final payload =
+          jsonDecode(buildLanIdentityPayload('identity-id', bindIdentity: true))
+              as Map<String, dynamic>;
+
+      expect(payload, {
+        'lan_version': 1,
+        'identity_id': 'identity-id',
+        'bind_identity': true,
+      });
+      expect(payload.containsKey('username'), isFalse);
+      expect(payload.containsKey('password'), isFalse);
+    });
+  });
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -15,7 +15,7 @@ use magnum_opus::{Channels::*, Decoder as AudioDecoder};
 use ringbuf::{ring_buffer::RbBase, Rb};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     ffi::c_void,
     net::SocketAddr,
     ops::Deref,
@@ -111,6 +111,73 @@ const LAN_CREDENTIAL_USERNAME_OPTION: &str = "lan-access-username";
 const LAN_CREDENTIAL_KEYRING_SERVICE: &str = "com.zibochen.SubnetDesk.LANCredentials";
 pub const LOGIN_MSG_OFFLINE: &str = "Offline";
 pub const LOGIN_SCREEN_WAYLAND: &str = "Wayland login screen is not supported";
+
+fn lan_credential_config_id_for_fingerprint(fingerprint: &str) -> Option<String> {
+    if fingerprint.len() != 64 || !fingerprint.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        None
+    } else {
+        Some(format!(
+            "{LAN_CREDENTIAL_CONFIG_PREFIX}{}",
+            fingerprint.to_ascii_lowercase()
+        ))
+    }
+}
+
+pub(crate) fn load_remembered_lan_credential_for_fingerprint(
+    fingerprint: &str,
+) -> Option<(String, Vec<u8>)> {
+    let config_id = lan_credential_config_id_for_fingerprint(fingerprint)?;
+    let config = PeerConfig::load(&config_id);
+    let username = config
+        .options
+        .get(LAN_CREDENTIAL_USERNAME_OPTION)
+        .cloned()?;
+    if hbb_common::lan::validate_username(&username).is_err() {
+        return None;
+    }
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+    {
+        let entry = match keyring::Entry::new(LAN_CREDENTIAL_KEYRING_SERVICE, &config_id) {
+            Ok(entry) => entry,
+            Err(err) => {
+                log::warn!("Failed to open the operating system credential store: {err}");
+                return None;
+            }
+        };
+        let mut password = match entry.get_password() {
+            Ok(password) => password,
+            Err(keyring::Error::NoEntry) => return None,
+            Err(err) => {
+                log::warn!("Failed to read the remembered LAN credential: {err}");
+                return None;
+            }
+        };
+        if hbb_common::lan::validate_password(password.as_bytes()).is_err() {
+            password.zeroize();
+            return None;
+        }
+        let password_bytes = password.as_bytes().to_vec();
+        password.zeroize();
+        Some((username, password_bytes))
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        None
+    }
+}
+
+pub(crate) fn clear_remembered_lan_credential_for_fingerprint(fingerprint: &str) {
+    if let Some(config_id) = lan_credential_config_id_for_fingerprint(fingerprint) {
+        #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+        match keyring::Entry::new(LAN_CREDENTIAL_KEYRING_SERVICE, &config_id)
+            .and_then(|entry| entry.delete_password())
+        {
+            Ok(()) | Err(keyring::Error::NoEntry) => {}
+            Err(err) => log::warn!("Failed to delete the remembered LAN credential: {err}"),
+        }
+        PeerConfig::remove(&config_id);
+    }
+}
 #[cfg(target_os = "linux")]
 pub const SCRAP_UBUNTU_HIGHER_REQUIRED: &str = "ubuntu-21-04-required";
 #[cfg(target_os = "linux")]
@@ -174,13 +241,14 @@ pub fn get_key_state(key: enigo::Key) -> bool {
 
 impl Client {
     const CLIENT_CLIPBOARD_NAME: &'static str = "client-clipboard";
+    const KNOWN_DEVICE_CONNECT_TIMEOUT: u64 = 5_000;
 
     /// Start a new encrypted LAN connection.
     pub async fn start(
         peer: &str,
         _conn_type: ConnType,
         interface: impl Interface,
-    ) -> ResultType<(Stream, Vec<u8>)> {
+    ) -> ResultType<(Stream, Vec<u8>, String)> {
         if config::is_incoming_only() {
             bail!("Incoming only mode");
         }
@@ -194,17 +262,98 @@ impl Client {
         interface.update_direct(Some(true));
         interface.update_received(false);
 
-        let endpoint = hbb_common::lan::Endpoint::parse(peer)?;
-        let mut stream = connect_tcp_local(endpoint.authority(), None, CONNECT_TIMEOUT)
-            .await
-            .with_context(|| format!("Failed to connect to {endpoint}"))?;
-        let identity = crate::lan_protocol::client_handshake(&mut stream).await?;
-        log::info!(
-            "Established encrypted LAN connection to {} with fingerprint {}",
-            endpoint,
-            identity.fingerprint
-        );
-        Ok((stream, identity.device_public_key))
+        let requested = hbb_common::lan::Endpoint::parse(peer)?
+            .authority()
+            .to_owned();
+        let (expected_fingerprint, mut candidates) = crate::lan::connection_candidates(&requested);
+        let mut discovery = expected_fingerprint.as_ref().map(|_| {
+            tokio::spawn(async {
+                if let Err(err) = crate::lan::discover_async().await {
+                    log::debug!("LAN discovery during connection fallback failed: {err}");
+                }
+            })
+        });
+        let mut attempted = HashSet::new();
+        let mut errors = Vec::new();
+
+        loop {
+            for candidate in std::mem::take(&mut candidates) {
+                if !attempted.insert(candidate.clone()) {
+                    continue;
+                }
+                let timeout = if expected_fingerprint.is_some() {
+                    Self::KNOWN_DEVICE_CONNECT_TIMEOUT
+                } else {
+                    CONNECT_TIMEOUT
+                };
+                let endpoint = match hbb_common::lan::Endpoint::parse(&candidate) {
+                    Ok(endpoint) => endpoint,
+                    Err(err) => {
+                        errors.push(format!("{candidate}: {err}"));
+                        continue;
+                    }
+                };
+                let mut stream = match connect_tcp_local(endpoint.authority(), None, timeout).await
+                {
+                    Ok(stream) => stream,
+                    Err(err) => {
+                        errors.push(format!("{endpoint}: {err}"));
+                        continue;
+                    }
+                };
+                let identity = match crate::lan_protocol::client_handshake(&mut stream).await {
+                    Ok(identity) => identity,
+                    Err(err) => {
+                        errors.push(format!("{endpoint}: {err}"));
+                        continue;
+                    }
+                };
+                if let Some(expected) = expected_fingerprint.as_ref() {
+                    if !identity.fingerprint.eq_ignore_ascii_case(expected) {
+                        log::warn!(
+                            "Ignoring LAN endpoint {} because it belongs to fingerprint {}, expected {}",
+                            endpoint,
+                            identity.fingerprint,
+                            expected
+                        );
+                        errors.push(format!("{endpoint}: device identity did not match"));
+                        continue;
+                    }
+                }
+
+                let connected_endpoint = endpoint.authority().to_owned();
+                interface.get_lch().write().unwrap().lan_connected_endpoint =
+                    connected_endpoint.clone();
+                log::info!(
+                    "Established encrypted LAN connection to {} with fingerprint {}",
+                    endpoint,
+                    identity.fingerprint
+                );
+                return Ok((stream, identity.device_public_key, connected_endpoint));
+            }
+
+            if let Some(discovery) = discovery.take() {
+                if let Err(err) = discovery.await {
+                    log::debug!("LAN discovery fallback task failed: {err}");
+                }
+                let (_, refreshed) = crate::lan::connection_candidates(&requested);
+                candidates = refreshed;
+                if candidates
+                    .iter()
+                    .all(|candidate| attempted.contains(candidate))
+                {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+
+        let detail = errors
+            .last()
+            .cloned()
+            .unwrap_or_else(|| "no usable LAN endpoint was found".to_owned());
+        bail!("Failed to connect to {requested}: {detail}")
     }
 
     #[inline]
@@ -984,6 +1133,7 @@ pub struct LoginConfigHandler {
     pub peer_info: Option<PeerInfo>,
     pub lan_access_username: String,
     pub lan_fingerprint: String,
+    pub lan_connected_endpoint: String,
     pub record_state: bool,
     pub record_permission: bool,
 }
@@ -1026,6 +1176,7 @@ impl LoginConfigHandler {
         self.adapter_luid = adapter_luid;
         self.selected_windows_session_id = None;
         self.lan_fingerprint.clear();
+        self.lan_connected_endpoint.clear();
         self.record_state = false;
         self.record_permission = true;
 
@@ -1065,55 +1216,11 @@ impl LoginConfigHandler {
     }
 
     fn lan_credential_config_id(&self) -> Option<String> {
-        if self.lan_fingerprint.is_empty() {
-            None
-        } else {
-            Some(format!(
-                "{LAN_CREDENTIAL_CONFIG_PREFIX}{}",
-                self.lan_fingerprint
-            ))
-        }
+        lan_credential_config_id_for_fingerprint(&self.lan_fingerprint)
     }
 
     pub fn load_remembered_lan_credential(&self) -> Option<(String, Vec<u8>)> {
-        let config_id = self.lan_credential_config_id()?;
-        let config = PeerConfig::load(&config_id);
-        let username = config
-            .options
-            .get(LAN_CREDENTIAL_USERNAME_OPTION)
-            .cloned()?;
-        if hbb_common::lan::validate_username(&username).is_err() {
-            return None;
-        }
-        #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
-        {
-            let entry = match keyring::Entry::new(LAN_CREDENTIAL_KEYRING_SERVICE, &config_id) {
-                Ok(entry) => entry,
-                Err(err) => {
-                    log::warn!("Failed to open the operating system credential store: {err}");
-                    return None;
-                }
-            };
-            let mut password = match entry.get_password() {
-                Ok(password) => password,
-                Err(keyring::Error::NoEntry) => return None,
-                Err(err) => {
-                    log::warn!("Failed to read the remembered LAN credential: {err}");
-                    return None;
-                }
-            };
-            if hbb_common::lan::validate_password(password.as_bytes()).is_err() {
-                password.zeroize();
-                return None;
-            }
-            let password_bytes = password.as_bytes().to_vec();
-            password.zeroize();
-            Some((username, password_bytes))
-        }
-        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-        {
-            None
-        }
+        load_remembered_lan_credential_for_fingerprint(&self.lan_fingerprint)
     }
 
     pub fn save_remembered_lan_credential(
@@ -1152,16 +1259,7 @@ impl LoginConfigHandler {
     }
 
     pub fn clear_remembered_lan_credential(&self) {
-        if let Some(config_id) = self.lan_credential_config_id() {
-            #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
-            match keyring::Entry::new(LAN_CREDENTIAL_KEYRING_SERVICE, &config_id)
-                .and_then(|entry| entry.delete_password())
-            {
-                Ok(()) | Err(keyring::Error::NoEntry) => {}
-                Err(err) => log::warn!("Failed to delete the remembered LAN credential: {err}"),
-            }
-            PeerConfig::remove(&config_id);
-        }
+        clear_remembered_lan_credential_for_fingerprint(&self.lan_fingerprint);
     }
 
     /// Set an option for handler's [`PeerConfig`].
@@ -1790,9 +1888,35 @@ impl LoginConfigHandler {
         }
         // no matter if change, for update file time
         self.save_config(config);
+        let connected_endpoint = if self.lan_connected_endpoint.is_empty() {
+            self.id.clone()
+        } else {
+            self.lan_connected_endpoint.clone()
+        };
+        if connected_endpoint != self.id && !self.lan_fingerprint.is_empty() {
+            self.config.store(&connected_endpoint);
+            let mut changed = false;
+            let mut seen = HashSet::new();
+            let favorites = LocalConfig::get_fav()
+                .into_iter()
+                .filter_map(|favorite| {
+                    let favorite = if favorite == self.id {
+                        changed = true;
+                        connected_endpoint.clone()
+                    } else {
+                        favorite
+                    };
+                    seen.insert(favorite.clone()).then_some(favorite)
+                })
+                .collect::<Vec<_>>();
+            if changed {
+                LocalConfig::set_fav(favorites);
+            }
+            LocalConfig::set_remote_id(&connected_endpoint);
+        }
         if !self.lan_fingerprint.is_empty() && !self.lan_access_username.is_empty() {
             if let Err(err) = LocalConfig::record_recent_lan_endpoint(
-                &self.id,
+                &connected_endpoint,
                 &self.lan_access_username,
                 &pi.hostname,
                 &pi.platform,

--- a/src/client/io_loop.rs
+++ b/src/client/io_loop.rs
@@ -169,12 +169,12 @@ impl<T: InvokeUiSession> Remote<T> {
         };
 
         match Client::start(&self.handler.get_id(), conn_type, self.handler.clone()).await {
-            Ok((mut peer, device_public_key)) => {
+            Ok((mut peer, device_public_key, connected_endpoint)) => {
                 if device_public_key.is_empty()
                     || !client::confirm_lan_device(
                         &self.handler,
                         &mut self.receiver,
-                        &self.handler.get_id(),
+                        &connected_endpoint,
                         &device_public_key,
                     )
                     .await

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -1,7 +1,9 @@
 use crate::{
     client::*,
     flutter_ffi::{EventToUI, SessionID},
-    ui_session_interface::{io_loop, InvokeUiSession, LanSessionCredential, Session},
+    ui_session_interface::{
+        io_loop, InvokeUiSession, LanIdentityRequest, LanSessionCredential, Session,
+    },
 };
 use flutter_rust_bridge::StreamSink;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -47,10 +49,16 @@ pub type FlutterSession = Arc<Session<FlutterHandler>>;
 #[derive(Deserialize)]
 struct LanCredentialPayload {
     lan_version: u32,
+    #[serde(default)]
+    identity_id: String,
+    #[serde(default)]
     username: String,
+    #[serde(default)]
     password: String,
     #[serde(default)]
     remember: bool,
+    #[serde(default)]
+    bind_identity: bool,
 }
 
 lazy_static::lazy_static! {
@@ -1343,30 +1351,58 @@ pub fn session_add(
 
     LocalConfig::set_remote_id(&id);
 
-    let lan_credential = if password.is_empty() {
-        None
+    let (lan_credential, lan_identity_request) = if password.is_empty() {
+        (None, None)
     } else {
         let payload: LanCredentialPayload = serde_json::from_str(&password)
             .map_err(|_| anyhow!("Invalid LAN credential payload"))?;
         if payload.lan_version != hbb_common::lan::PROTOCOL_VERSION {
             bail!("Unsupported LAN credential payload version");
         }
-        let username = hbb_common::lan::validate_username(&payload.username)?;
-        hbb_common::lan::validate_password(payload.password.as_bytes())?;
-        Some(LanSessionCredential {
-            username,
-            password: payload.password.into_bytes(),
-            remember: payload.remember,
-        })
+        if !payload.identity_id.is_empty() {
+            if !payload.username.is_empty() || !payload.password.is_empty() {
+                bail!("LAN identity payload must not include plaintext credentials");
+            }
+            if LocalConfig::get_lan_identity(&payload.identity_id).is_none() {
+                bail!("LAN identity does not exist");
+            }
+            (
+                None,
+                Some(LanIdentityRequest {
+                    identity_id: payload.identity_id,
+                    bind_on_success: payload.bind_identity,
+                }),
+            )
+        } else {
+            let username = hbb_common::lan::validate_username(&payload.username)?;
+            hbb_common::lan::validate_password(payload.password.as_bytes())?;
+            (
+                Some(LanSessionCredential {
+                    username,
+                    password: payload.password.into_bytes(),
+                    remember: payload.remember,
+                    identity_id: String::new(),
+                    bind_identity_on_success: false,
+                }),
+                None,
+            )
+        }
     };
     let lan_access_username = lan_credential
         .as_ref()
         .map(|credential| credential.username.clone())
+        .or_else(|| {
+            lan_identity_request.as_ref().and_then(|request| {
+                LocalConfig::get_lan_identity(&request.identity_id)
+                    .map(|identity| identity.username)
+            })
+        })
         .unwrap_or_default();
     zeroize::Zeroize::zeroize(&mut password);
     let session: Session<FlutterHandler> = Session {
         password: String::new(),
         lan_credential: Arc::new(std::sync::Mutex::new(lan_credential)),
+        lan_identity_request: Arc::new(std::sync::Mutex::new(lan_identity_request)),
         server_keyboard_enabled: Arc::new(RwLock::new(true)),
         server_file_transfer_enabled: Arc::new(RwLock::new(true)),
         server_clipboard_enabled: Arc::new(RwLock::new(true)),

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -254,6 +254,17 @@ pub fn session_login_lan(
     SyncReturn(result.err().map(|err| err.to_string()).unwrap_or_default())
 }
 
+pub fn session_login_lan_identity(
+    session_id: SessionID,
+    identity_id: String,
+    bind_on_success: bool,
+) -> SyncReturn<String> {
+    let result = sessions::get_session_by_session_id(&session_id)
+        .ok_or_else(|| hbb_common::anyhow::anyhow!("Session is no longer available"))
+        .and_then(|session| session.submit_lan_identity(identity_id, bind_on_success));
+    SyncReturn(result.err().map(|err| err.to_string()).unwrap_or_default())
+}
+
 pub fn will_session_close_close_session(session_id: SessionID) -> SyncReturn<bool> {
     SyncReturn(sessions::would_remove_peer_by_session_id(&session_id))
 }
@@ -1032,6 +1043,107 @@ pub fn main_get_peer_sync(id: String) -> SyncReturn<String> {
 
 pub fn main_get_lan_peers() -> String {
     serde_json::to_string(&get_lan_peers()).unwrap_or_default()
+}
+
+pub fn main_list_lan_identities() -> SyncReturn<String> {
+    SyncReturn(serde_json::to_string(&crate::lan_identity::list()).unwrap_or_default())
+}
+
+pub fn main_create_lan_identity(
+    name: String,
+    username: String,
+    mut password: String,
+    make_default: bool,
+) -> SyncReturn<String> {
+    let result = crate::lan_identity::create(&name, &username, &password, make_default);
+    zeroize::Zeroize::zeroize(&mut password);
+    SyncReturn(match result {
+        Ok(identity_id) => serde_json::json!({
+            "identity_id": identity_id,
+            "error": "",
+        })
+        .to_string(),
+        Err(err) => serde_json::json!({
+            "identity_id": "",
+            "error": err.to_string(),
+        })
+        .to_string(),
+    })
+}
+
+pub fn main_update_lan_identity(
+    identity_id: String,
+    name: String,
+    username: String,
+    mut password: String,
+    make_default: bool,
+) -> SyncReturn<String> {
+    let password_update = (!password.is_empty()).then_some(password.as_str());
+    let result = crate::lan_identity::update(
+        &identity_id,
+        &name,
+        &username,
+        password_update,
+        make_default,
+    );
+    zeroize::Zeroize::zeroize(&mut password);
+    SyncReturn(result.err().map(|err| err.to_string()).unwrap_or_default())
+}
+
+pub fn main_delete_lan_identity(identity_id: String) -> SyncReturn<String> {
+    SyncReturn(
+        crate::lan_identity::delete(&identity_id)
+            .err()
+            .map(|err| err.to_string())
+            .unwrap_or_default(),
+    )
+}
+
+pub fn main_set_default_lan_identity(identity_id: String) -> SyncReturn<String> {
+    SyncReturn(
+        crate::lan_identity::set_default(&identity_id)
+            .err()
+            .map(|err| err.to_string())
+            .unwrap_or_default(),
+    )
+}
+
+pub fn main_bind_lan_identity(fingerprint: String, identity_id: String) -> SyncReturn<String> {
+    SyncReturn(
+        crate::lan_identity::bind(&fingerprint, &identity_id)
+            .err()
+            .map(|err| err.to_string())
+            .unwrap_or_default(),
+    )
+}
+
+pub fn main_get_bound_lan_identity_id(fingerprint: String) -> SyncReturn<String> {
+    SyncReturn(crate::lan_identity::bound_identity_id(&fingerprint))
+}
+
+pub fn main_has_legacy_lan_credential(fingerprint: String) -> SyncReturn<bool> {
+    SyncReturn(crate::lan_identity::has_legacy_credential(&fingerprint))
+}
+
+pub fn main_import_legacy_lan_credential(
+    fingerprint: String,
+    name: String,
+    make_default: bool,
+) -> SyncReturn<String> {
+    SyncReturn(
+        match crate::lan_identity::import_legacy_credential(&fingerprint, &name, make_default) {
+            Ok(identity_id) => serde_json::json!({
+                "identity_id": identity_id,
+                "error": "",
+            })
+            .to_string(),
+            Err(err) => serde_json::json!({
+                "identity_id": "",
+                "error": err.to_string(),
+            })
+            .to_string(),
+        },
+    )
 }
 
 pub fn main_get_connect_status() -> String {

--- a/src/lan.rs
+++ b/src/lan.rs
@@ -16,7 +16,7 @@ use hbb_common::{
 };
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     net::{IpAddr, Ipv4Addr, SocketAddr, ToSocketAddrs, UdpSocket},
     time::Instant,
 };
@@ -121,8 +121,7 @@ pub(super) fn start_listening() -> ResultType<()> {
     }
 }
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn discover() -> ResultType<()> {
+pub(crate) async fn discover_async() -> ResultType<()> {
     let (tx, rx) = unbounded_channel::<_>();
     let mut worker_started = false;
     match send_query() {
@@ -145,6 +144,86 @@ pub async fn discover() -> ResultType<()> {
 
     log::info!("discover ping done");
     Ok(())
+}
+
+#[tokio::main(flavor = "current_thread")]
+pub async fn discover() -> ResultType<()> {
+    discover_async().await
+}
+
+pub(crate) fn connection_candidates(endpoint: &str) -> (Option<String>, Vec<String>) {
+    let recent = config::LocalConfig::get_recent_lan_endpoints();
+    let peers = config::LanPeers::load().peers;
+    connection_candidates_from(endpoint, &recent, &peers)
+}
+
+fn connection_candidates_from(
+    endpoint: &str,
+    recent: &[config::RecentLanEndpoint],
+    peers: &[config::DiscoveryPeer],
+) -> (Option<String>, Vec<String>) {
+    let Ok(requested) = hbb_common::lan::Endpoint::parse(endpoint) else {
+        return (None, vec![endpoint.to_owned()]);
+    };
+    let requested = requested.authority().to_owned();
+    let mut fingerprint = recent
+        .iter()
+        .find(|recent| recent.endpoint == requested)
+        .map(|recent| recent.fingerprint.to_ascii_lowercase());
+
+    if fingerprint.is_none() {
+        fingerprint = peers.iter().find_map(|peer| {
+            if peer.endpoint == requested {
+                return Some(peer.fingerprint.to_ascii_lowercase());
+            }
+            let requested_endpoint = hbb_common::lan::Endpoint::parse(&requested).ok()?;
+            if peer.ip_mac.contains_key(requested_endpoint.host()) {
+                Some(peer.fingerprint.to_ascii_lowercase())
+            } else {
+                None
+            }
+        });
+    }
+    let fingerprint = fingerprint
+        .filter(|value| value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit()));
+
+    let mut candidates = Vec::new();
+    push_unique(&mut candidates, requested);
+    if let Some(fingerprint) = fingerprint.as_ref() {
+        for recent in recent
+            .iter()
+            .filter(|recent| recent.fingerprint.eq_ignore_ascii_case(fingerprint))
+        {
+            push_unique(&mut candidates, recent.endpoint.clone());
+        }
+        for peer in peers
+            .iter()
+            .filter(|peer| peer.fingerprint.eq_ignore_ascii_case(fingerprint))
+        {
+            push_unique(&mut candidates, peer.endpoint.clone());
+            let port = hbb_common::lan::Endpoint::parse(&peer.endpoint)
+                .map(|endpoint| endpoint.port())
+                .unwrap_or(hbb_common::lan::DEFAULT_PORT);
+            let mut addresses = peer.ip_mac.keys().collect::<Vec<_>>();
+            addresses.sort();
+            for address in addresses {
+                if let Ok(address) = address.parse::<IpAddr>() {
+                    let endpoint = match address {
+                        IpAddr::V4(address) => format!("{address}:{port}"),
+                        IpAddr::V6(address) => format!("[{address}]:{port}"),
+                    };
+                    push_unique(&mut candidates, endpoint);
+                }
+            }
+        }
+    }
+    (fingerprint, candidates)
+}
+
+fn push_unique(values: &mut Vec<String>, value: String) {
+    if !value.is_empty() && !values.contains(&value) {
+        values.push(value);
+    }
 }
 
 pub fn send_wol(id: String) {
@@ -389,24 +468,21 @@ async fn handle_received_peers(mut rx: UnboundedReceiver<config::DiscoveryPeer>)
         peer.online = false;
     });
 
-    let mut response_set = HashSet::new();
     let mut last_write_time: Option<Instant> = None;
     loop {
         tokio::select! {
             data = rx.recv() => match data {
                 Some(mut peer) => {
-                    let response_key = if peer.fingerprint.is_empty() {
-                        peer.id.clone()
-                    } else {
-                        peer.fingerprint.clone()
-                    };
-                    let in_response_set = !response_set.insert(response_key);
                     if let Some(pos) = peers.iter().position(|x| x.is_same_peer(&peer) ) {
                         let peer1 = peers.remove(pos);
-                        if in_response_set {
-                            peer.ip_mac.extend(peer1.ip_mac);
-                            peer.online = true;
+                        if let Ok(endpoint) = hbb_common::lan::Endpoint::parse(&peer1.endpoint) {
+                            if endpoint.host().parse::<IpAddr>().is_ok() {
+                                peer.ip_mac
+                                    .entry(endpoint.host().to_owned())
+                                    .or_default();
+                            }
                         }
+                        peer.ip_mac.extend(peer1.ip_mac);
                     }
                     peers.insert(0, peer);
                     if last_write_time.map(|t| t.elapsed().as_millis() > 300).unwrap_or(true)  {
@@ -448,5 +524,56 @@ mod tests {
         );
         assert_eq!(select_device_display_name("", "host.local"), "host.local");
         assert_eq!(select_device_display_name("", "\n"), "SubnetDesk");
+    }
+
+    #[test]
+    fn connection_candidates_keep_vpn_endpoint_and_add_discovered_addresses() {
+        let fingerprint = "a".repeat(64);
+        let recent = config::RecentLanEndpoint {
+            endpoint: "10.8.0.15:21118".to_owned(),
+            fingerprint: fingerprint.clone(),
+            ..Default::default()
+        };
+        let peers = vec![config::DiscoveryPeer {
+            endpoint: "192.168.1.99:21118".to_owned(),
+            fingerprint: fingerprint.clone(),
+            ip_mac: HashMap::from([
+                ("192.168.1.99".to_owned(), String::new()),
+                ("10.8.0.15".to_owned(), String::new()),
+            ]),
+            ..Default::default()
+        }];
+
+        let (resolved_fingerprint, candidates) =
+            connection_candidates_from(&recent.endpoint, &[recent.clone()], &peers);
+
+        assert_eq!(resolved_fingerprint, Some(fingerprint));
+        assert_eq!(candidates[0], "10.8.0.15:21118");
+        assert!(candidates.contains(&"192.168.1.99:21118".to_owned()));
+        assert_eq!(
+            candidates
+                .iter()
+                .filter(|endpoint| endpoint.as_str() == "10.8.0.15:21118")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn connection_candidates_can_identify_device_from_discovery_cache() {
+        let fingerprint = "b".repeat(64);
+        let peers = vec![config::DiscoveryPeer {
+            endpoint: "192.168.1.20:21118".to_owned(),
+            fingerprint: fingerprint.clone(),
+            ip_mac: HashMap::from([("10.9.0.20".to_owned(), String::new())]),
+            ..Default::default()
+        }];
+
+        let (resolved_fingerprint, candidates) =
+            connection_candidates_from("10.9.0.20:21118", &[], &peers);
+
+        assert_eq!(resolved_fingerprint, Some(fingerprint));
+        assert_eq!(candidates[0], "10.9.0.20:21118");
+        assert!(candidates.contains(&"192.168.1.20:21118".to_owned()));
     }
 }

--- a/src/lan_identity.rs
+++ b/src/lan_identity.rs
@@ -1,0 +1,288 @@
+use hbb_common::{
+    anyhow::{anyhow, bail},
+    config::{LanIdentity, LocalConfig},
+    lan::{validate_password, validate_username},
+    log, ResultType,
+};
+use serde::Serialize;
+use uuid::Uuid;
+use zeroize::{Zeroize, Zeroizing};
+
+const MAX_IDENTITY_NAME_LEN: usize = 64;
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+const LAN_IDENTITY_KEYRING_SERVICE: &str = "com.zibochen.SubnetDesk.LANIdentities";
+
+#[derive(Debug, Serialize)]
+pub struct LanIdentitySummary {
+    pub id: String,
+    pub name: String,
+    pub username: String,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub is_default: bool,
+}
+
+pub struct ResolvedLanIdentity {
+    pub id: String,
+    pub username: String,
+    pub password: Vec<u8>,
+}
+
+fn validate_identity_name(name: &str) -> ResultType<String> {
+    let name = name.trim();
+    if name.is_empty() {
+        bail!("Identity name is required");
+    }
+    if name.len() > MAX_IDENTITY_NAME_LEN {
+        bail!("Identity name is too long");
+    }
+    if name.chars().any(char::is_control) {
+        bail!("Identity name contains control characters");
+    }
+    Ok(name.to_owned())
+}
+
+fn validate_identity_id(identity_id: &str) -> ResultType<String> {
+    let identity_id = Uuid::parse_str(identity_id)
+        .map_err(|_| anyhow!("Invalid LAN identity ID"))?
+        .to_string();
+    Ok(identity_id)
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+fn keyring_entry(identity_id: &str) -> ResultType<keyring::Entry> {
+    keyring::Entry::new(LAN_IDENTITY_KEYRING_SERVICE, identity_id)
+        .map_err(|err| anyhow!("Failed to open the operating system credential store: {err}"))
+}
+
+fn ensure_unique_name(name: &str, excluding_id: Option<&str>) -> ResultType<()> {
+    if LocalConfig::lan_identity_name_exists(name, excluding_id) {
+        bail!("An identity with this name already exists");
+    }
+    Ok(())
+}
+
+pub fn list() -> Vec<LanIdentitySummary> {
+    let default_id = LocalConfig::get_default_lan_identity_id();
+    LocalConfig::get_lan_identities()
+        .into_iter()
+        .map(|identity| LanIdentitySummary {
+            is_default: identity.id == default_id,
+            id: identity.id,
+            name: identity.name,
+            username: identity.username,
+            created_at: identity.created_at,
+            updated_at: identity.updated_at,
+        })
+        .collect()
+}
+
+pub fn create(
+    name: &str,
+    username: &str,
+    password: &str,
+    make_default: bool,
+) -> ResultType<String> {
+    let name = validate_identity_name(name)?;
+    let username = validate_username(username)?;
+    validate_password(password.as_bytes())?;
+    ensure_unique_name(&name, None)?;
+    let identity_id = Uuid::new_v4().to_string();
+
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+    keyring_entry(&identity_id)?
+        .set_password(password)
+        .map_err(|err| anyhow!("Failed to save the LAN identity password: {err}"))?;
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        let _ = password;
+        bail!("LAN identities are not supported on this platform");
+    }
+
+    let now = hbb_common::get_time();
+    LocalConfig::store_lan_identity(LanIdentity {
+        id: identity_id.clone(),
+        name,
+        username,
+        created_at: now,
+        updated_at: now,
+    });
+    if make_default {
+        LocalConfig::set_default_lan_identity_id(&identity_id)?;
+    }
+    Ok(identity_id)
+}
+
+pub fn update(
+    identity_id: &str,
+    name: &str,
+    username: &str,
+    password: Option<&str>,
+    make_default: bool,
+) -> ResultType<()> {
+    let identity_id = validate_identity_id(identity_id)?;
+    let name = validate_identity_name(name)?;
+    let username = validate_username(username)?;
+    ensure_unique_name(&name, Some(&identity_id))?;
+    let mut identity = LocalConfig::get_lan_identity(&identity_id)
+        .ok_or_else(|| anyhow!("LAN identity does not exist"))?;
+
+    if let Some(password) = password {
+        validate_password(password.as_bytes())?;
+        #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+        keyring_entry(&identity_id)?
+            .set_password(password)
+            .map_err(|err| anyhow!("Failed to update the LAN identity password: {err}"))?;
+        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+        {
+            let _ = password;
+            bail!("LAN identities are not supported on this platform");
+        }
+    }
+
+    identity.name = name;
+    identity.username = username;
+    identity.updated_at = hbb_common::get_time();
+    LocalConfig::store_lan_identity(identity);
+    if make_default {
+        LocalConfig::set_default_lan_identity_id(&identity_id)?;
+    } else if LocalConfig::get_default_lan_identity_id() == identity_id {
+        LocalConfig::set_default_lan_identity_id("")?;
+    }
+    Ok(())
+}
+
+pub fn delete(identity_id: &str) -> ResultType<()> {
+    let identity_id = validate_identity_id(identity_id)?;
+    if LocalConfig::get_lan_identity(&identity_id).is_none() {
+        bail!("LAN identity does not exist");
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+    match keyring_entry(&identity_id)?.delete_password() {
+        Ok(()) | Err(keyring::Error::NoEntry) => {}
+        Err(err) => bail!("Failed to delete the LAN identity password: {err}"),
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    bail!("LAN identities are not supported on this platform");
+
+    LocalConfig::remove_lan_identity(&identity_id);
+    Ok(())
+}
+
+pub fn set_default(identity_id: &str) -> ResultType<()> {
+    if identity_id.is_empty() {
+        return LocalConfig::set_default_lan_identity_id("");
+    }
+    let identity_id = validate_identity_id(identity_id)?;
+    LocalConfig::set_default_lan_identity_id(&identity_id)
+}
+
+pub fn bind(fingerprint: &str, identity_id: &str) -> ResultType<()> {
+    if identity_id.is_empty() {
+        return LocalConfig::bind_lan_identity(fingerprint, "");
+    }
+    let identity_id = validate_identity_id(identity_id)?;
+    LocalConfig::bind_lan_identity(fingerprint, &identity_id)
+}
+
+pub fn bound_identity_id(fingerprint: &str) -> String {
+    LocalConfig::get_bound_lan_identity_id(fingerprint)
+}
+
+pub fn resolved_identity_id(fingerprint: &str) -> String {
+    LocalConfig::resolve_lan_identity_id(fingerprint)
+}
+
+pub fn load(identity_id: &str) -> ResultType<ResolvedLanIdentity> {
+    let identity_id = validate_identity_id(identity_id)?;
+    let identity = LocalConfig::get_lan_identity(&identity_id)
+        .ok_or_else(|| anyhow!("LAN identity does not exist"))?;
+
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+    {
+        let mut password =
+            keyring_entry(&identity_id)?
+                .get_password()
+                .map_err(|err| match err {
+                    keyring::Error::NoEntry => anyhow!("LAN identity password is missing"),
+                    _ => anyhow!("Failed to read the LAN identity password: {err}"),
+                })?;
+        if let Err(err) = validate_password(password.as_bytes()) {
+            password.zeroize();
+            return Err(err);
+        }
+        let password_bytes = password.as_bytes().to_vec();
+        password.zeroize();
+        Ok(ResolvedLanIdentity {
+            id: identity_id,
+            username: identity.username,
+            password: password_bytes,
+        })
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    bail!("LAN identities are not supported on this platform")
+}
+
+pub fn load_for_fingerprint(fingerprint: &str) -> ResultType<Option<ResolvedLanIdentity>> {
+    let identity_id = resolved_identity_id(fingerprint);
+    if identity_id.is_empty() {
+        Ok(None)
+    } else {
+        load(&identity_id).map(Some)
+    }
+}
+
+pub fn has_legacy_credential(fingerprint: &str) -> bool {
+    crate::client::load_remembered_lan_credential_for_fingerprint(fingerprint).is_some()
+}
+
+pub fn import_legacy_credential(
+    fingerprint: &str,
+    name: &str,
+    make_default: bool,
+) -> ResultType<String> {
+    let (username, password) =
+        crate::client::load_remembered_lan_credential_for_fingerprint(fingerprint)
+            .ok_or_else(|| anyhow!("No remembered credential exists for this device"))?;
+    let password = Zeroizing::new(password);
+    let password_text = std::str::from_utf8(&password)
+        .map_err(|_| anyhow!("Remembered LAN password is not valid UTF-8"))?;
+    let identity_id = create(name, &username, password_text, make_default)?;
+    if let Err(err) = bind(fingerprint, &identity_id) {
+        if let Err(delete_err) = delete(&identity_id) {
+            log::error!(
+                "Failed to roll back imported LAN identity after binding failed: {delete_err}"
+            );
+        }
+        return Err(err);
+    }
+    crate::client::clear_remembered_lan_credential_for_fingerprint(fingerprint);
+    Ok(identity_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity_name_validation_trims_and_rejects_controls() {
+        assert_eq!(
+            validate_identity_name("  Operators  ").unwrap(),
+            "Operators"
+        );
+        assert!(validate_identity_name("").is_err());
+        assert!(validate_identity_name("bad\nname").is_err());
+        assert!(validate_identity_name(&"x".repeat(MAX_IDENTITY_NAME_LEN + 1)).is_err());
+    }
+
+    #[test]
+    fn identity_id_validation_is_canonical() {
+        let identity_id = Uuid::new_v4();
+        assert_eq!(
+            validate_identity_id(&identity_id.to_string()).unwrap(),
+            identity_id.to_string()
+        );
+        assert!(validate_identity_id("not-an-id").is_err());
+    }
+}

--- a/src/lan_mdns.rs
+++ b/src/lan_mdns.rs
@@ -257,7 +257,16 @@ fn peer_from_mdns_fields(
         .copied()
         .filter(|address| connectable_address(*address))
         .collect::<Vec<_>>();
-    addresses.sort_by_key(|address| (address_priority(*address), *address));
+    let local_ipv4_networks = default_net::get_interfaces()
+        .into_iter()
+        .flat_map(|interface| {
+            interface
+                .ipv4
+                .into_iter()
+                .map(|network| (network.addr, network.netmask))
+        })
+        .collect::<Vec<_>>();
+    addresses.sort_by_key(|address| (address_priority(*address, &local_ipv4_networks), *address));
     addresses.dedup();
     let primary = addresses.first().copied()?;
     let endpoint = match primary {
@@ -307,12 +316,24 @@ fn connectable_address(address: IpAddr) -> bool {
     }
 }
 
-fn address_priority(address: IpAddr) -> u8 {
+fn address_priority(
+    address: IpAddr,
+    local_ipv4_networks: &[(std::net::Ipv4Addr, std::net::Ipv4Addr)],
+) -> u8 {
     match address {
-        IpAddr::V4(address) if address.is_private() => 0,
-        IpAddr::V6(address) if (address.segments()[0] & 0xfe00) == 0xfc00 => 1,
-        IpAddr::V4(_) => 2,
-        IpAddr::V6(_) => 3,
+        IpAddr::V4(address)
+            if address.is_private()
+                && local_ipv4_networks.iter().any(|(local, netmask)| {
+                    (u32::from(*local) & u32::from(*netmask))
+                        == (u32::from(address) & u32::from(*netmask))
+                }) =>
+        {
+            0
+        }
+        IpAddr::V4(address) if address.is_private() => 1,
+        IpAddr::V6(address) if (address.segments()[0] & 0xfe00) == 0xfc00 => 2,
+        IpAddr::V4(_) => 3,
+        IpAddr::V6(_) => 4,
     }
 }
 
@@ -520,5 +541,17 @@ mod tests {
             "fd00::24".parse().unwrap(),
             &configured
         ));
+    }
+
+    #[test]
+    fn same_subnet_address_is_preferred_over_other_private_networks() {
+        let local_networks = [(
+            "192.168.1.10".parse().unwrap(),
+            "255.255.255.0".parse().unwrap(),
+        )];
+        assert!(
+            address_priority("192.168.1.24".parse().unwrap(), &local_networks)
+                < address_priority("10.8.0.24".parse().unwrap(), &local_networks)
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod common;
 #[cfg(not(any(target_os = "ios")))]
 pub mod ipc;
 mod lan;
+mod lan_identity;
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 mod lan_mdns;
 mod lan_protocol;

--- a/src/port_forward.rs
+++ b/src/port_forward.rs
@@ -115,10 +115,17 @@ async fn connect_and_login(
     } else {
         ConnType::PORT_FORWARD
     };
-    let (mut stream, device_public_key) = Client::start(id, conn_type, interface.clone()).await?;
+    let (mut stream, device_public_key, connected_endpoint) =
+        Client::start(id, conn_type, interface.clone()).await?;
     interface.update_direct(Some(true));
     if device_public_key.is_empty()
-        || !crate::client::confirm_lan_device(&interface, ui_receiver, id, &device_public_key).await
+        || !crate::client::confirm_lan_device(
+            &interface,
+            ui_receiver,
+            &connected_endpoint,
+            &device_public_key,
+        )
+        .await
     {
         *close_port_forward = true;
         return Ok(None);

--- a/src/ui_session_interface.rs
+++ b/src/ui_session_interface.rs
@@ -58,12 +58,21 @@ pub struct LanSessionCredential {
     pub username: String,
     pub password: Vec<u8>,
     pub remember: bool,
+    pub identity_id: String,
+    pub bind_identity_on_success: bool,
+}
+
+#[derive(Clone, Default)]
+pub struct LanIdentityRequest {
+    pub identity_id: String,
+    pub bind_on_success: bool,
 }
 
 #[derive(Clone, Default)]
 pub struct Session<T: InvokeUiSession> {
     pub password: String,
     pub lan_credential: Arc<Mutex<Option<LanSessionCredential>>>,
+    pub lan_identity_request: Arc<Mutex<Option<LanIdentityRequest>>>,
     pub args: Vec<String>,
     pub lc: Arc<RwLock<LoginConfigHandler>>,
     pub sender: Arc<RwLock<Option<mpsc::UnboundedSender<Data>>>>,
@@ -215,10 +224,30 @@ impl<T: InvokeUiSession> Session<T> {
             username: username.clone(),
             password: password.as_bytes().to_vec(),
             remember,
+            identity_id: String::new(),
+            bind_identity_on_success: false,
         };
         password.zeroize();
         self.lc.write().unwrap().lan_access_username = username;
+        *self.lan_identity_request.lock().unwrap() = None;
         *self.lan_credential.lock().unwrap() = Some(credential);
+        self.send(Data::SubmitLanCredentials);
+        Ok(())
+    }
+
+    pub fn submit_lan_identity(
+        &self,
+        identity_id: String,
+        bind_on_success: bool,
+    ) -> hbb_common::ResultType<()> {
+        let identity = hbb_common::config::LocalConfig::get_lan_identity(&identity_id)
+            .ok_or_else(|| hbb_common::anyhow::anyhow!("LAN identity does not exist"))?;
+        self.lc.write().unwrap().lan_access_username = identity.username;
+        *self.lan_credential.lock().unwrap() = None;
+        *self.lan_identity_request.lock().unwrap() = Some(LanIdentityRequest {
+            identity_id,
+            bind_on_success,
+        });
         self.send(Data::SubmitLanCredentials);
         Ok(())
     }
@@ -1772,14 +1801,24 @@ impl<T: InvokeUiSession> Interface for Session<T> {
             );
         }
         self.update_privacy_mode();
-        // Authentication succeeded. Persist or remove the fingerprint-bound LAN
-        // credential only now, never when the user merely submits the dialog.
+        // Authentication succeeded. Persist the selected identity binding or the
+        // legacy fingerprint-bound credential only now, never when the user
+        // merely submits the dialog.
         if let Some(credential) = self.lan_credential.lock().unwrap().take() {
             let lc = self.lc.clone();
             let interface = self.clone();
             let _ = tokio::task::spawn_blocking(move || {
                 let lc = lc.read().unwrap();
-                if credential.remember {
+                if !credential.identity_id.is_empty() {
+                    if credential.bind_identity_on_success {
+                        if let Err(err) =
+                            crate::lan_identity::bind(&lc.lan_fingerprint, &credential.identity_id)
+                        {
+                            log::error!("Failed to bind LAN identity: {err}");
+                            interface.msgbox("error", "Failed", "Bind identity", "");
+                        }
+                    }
+                } else if credential.remember {
                     if let Err(err) = lc
                         .save_remembered_lan_credential(&credential.username, &credential.password)
                     {
@@ -1832,7 +1871,45 @@ impl<T: InvokeUiSession> Interface for Session<T> {
 
     async fn send_initial_lan_login(&self, peer: &mut Stream) {
         let mut credential = self.lan_credential();
+        let mut explicit_identity_requested = false;
         if credential.is_none() {
+            let requested_identity = self.lan_identity_request.lock().unwrap().clone();
+            explicit_identity_requested = requested_identity.is_some();
+            let fingerprint = self.lc.read().unwrap().lan_fingerprint.clone();
+            let identity_result = tokio::task::spawn_blocking(move || {
+                if let Some(request) = requested_identity {
+                    crate::lan_identity::load(&request.identity_id)
+                        .map(|identity| Some((identity, request.bind_on_success)))
+                } else {
+                    crate::lan_identity::load_for_fingerprint(&fingerprint)
+                        .map(|identity| identity.map(|identity| (identity, false)))
+                }
+            })
+            .await;
+            match identity_result {
+                Ok(Ok(Some((identity, bind_identity_on_success)))) => {
+                    let identity_credential = LanSessionCredential {
+                        username: identity.username,
+                        password: identity.password,
+                        remember: false,
+                        identity_id: identity.id,
+                        bind_identity_on_success,
+                    };
+                    self.lc.write().unwrap().lan_access_username =
+                        identity_credential.username.clone();
+                    *self.lan_credential.lock().unwrap() = Some(identity_credential.clone());
+                    credential = Some(identity_credential);
+                }
+                Ok(Ok(None)) => {}
+                Ok(Err(err)) => {
+                    log::warn!("Failed to load LAN identity: {err}");
+                }
+                Err(err) => {
+                    log::warn!("LAN identity credential task failed: {err}");
+                }
+            }
+        }
+        if credential.is_none() && !explicit_identity_requested {
             let lc = self.lc.clone();
             let remembered = match tokio::task::spawn_blocking(move || {
                 lc.read().unwrap().load_remembered_lan_credential()
@@ -1850,6 +1927,8 @@ impl<T: InvokeUiSession> Interface for Session<T> {
                     username,
                     password,
                     remember: true,
+                    identity_id: String::new(),
+                    bind_identity_on_success: false,
                 };
                 self.lc.write().unwrap().lan_access_username = remembered.username.clone();
                 *self.lan_credential.lock().unwrap() = Some(remembered.clone());


### PR DESCRIPTION
## 变更内容

- 新增可复用的 LAN 身份，支持新建、编辑、删除和默认身份
- 使用系统凭据库保存密码，配置和连接 JSON 不包含明文密码
- 支持按稳定设备指纹绑定身份，并在认证成功后持久化绑定
- 连接、设备菜单和重新认证窗口均可选择已保存身份
- 支持将旧版按设备保存的凭据导入身份
- 改进设备地址变化时的指纹和连接端点跟踪

## 原因

多台 LAN 设备使用相同账号密码时，逐台输入和保存凭据效率较低。全局身份允许一次创建、多设备复用，同时保持密码仅由操作系统安全存储管理。

## 影响

桌面端 LAN 页面增加身份管理入口。连接时优先使用显式选择、设备绑定或默认身份，并继续兼容旧凭据和手动账号密码。

## 验证

- `cargo check --lib --features flutter` 通过
- `cargo test -p hbb_common`：93 项通过
- `flutter test`：35 项通过
- `git diff --check` 通过
