### PR TITLE
Add favorite device groups

### DIFF
--- a/flutter/lib/common/widgets/peer_card.dart
+++ b/flutter/lib/common/widgets/peer_card.dart
@@ -10,6 +10,7 @@ import 'package:provider/provider.dart';
 import '../../common.dart';
 import '../../common/formatter/id_formatter.dart';
 import '../../desktop/lan_identity_manager.dart';
+import '../../models/favorite_group_model.dart';
 import '../../models/peer_model.dart';
 import '../../models/platform_model.dart';
 import '../../desktop/widgets/material_mod_popup_menu.dart' as mod_menu;
@@ -79,6 +80,7 @@ class _PeerCardState extends State<_PeerCard>
     final favorites = (await bind.mainGetFav()).toList();
     if (favorites.contains(widget.peer.id)) {
       favorites.remove(widget.peer.id);
+      favoriteGroupModel.removePeer(widget.peer.id);
     } else {
       favorites.add(widget.peer.id);
     }
@@ -955,6 +957,7 @@ abstract class BasePeerCard extends StatelessWidget {
               final favs = (await bind.mainGetFav()).toList();
               if (favs.remove(id)) {
                 await bind.mainStoreFav(favs: favs);
+                favoriteGroupModel.removePeer(id);
                 bind.mainLoadFavPeers();
               }
               break;
@@ -1030,6 +1033,7 @@ abstract class BasePeerCard extends StatelessWidget {
           final favs = (await bind.mainGetFav()).toList();
           if (favs.remove(id)) {
             await bind.mainStoreFav(favs: favs);
+            favoriteGroupModel.removePeer(id);
             await reloadFunc();
           }
           showToast(translate('Successful'));
@@ -1144,6 +1148,8 @@ class FavoritePeerCard extends BasePeerCard {
     if (isMobile || isDesktop || isWebDesktop) {
       menuItems.add(_renameAction(peer.id));
     }
+    favoriteGroupModel.load();
+    menuItems.add(_favoriteGroupAction(peer.id));
     menuItems.add(
       _rmFavAction(peer.id, () async {
         await bind.mainLoadFavPeers();
@@ -1158,6 +1164,53 @@ class FavoritePeerCard extends BasePeerCard {
   @protected
   @override
   void _update() => bind.mainLoadFavPeers();
+
+  MenuEntryBase<String> _favoriteGroupAction(String peerId) {
+    final selectedGroupId = favoriteGroupModel.groupIdForPeer(peerId);
+    final entries = <MenuEntryBase<String>>[
+      _favoriteGroupChoice(
+        peerId: peerId,
+        groupId: null,
+        label: translate('Other'),
+        selected: selectedGroupId == null,
+      ),
+      ...favoriteGroupModel.groups.map(
+        (group) => _favoriteGroupChoice(
+          peerId: peerId,
+          groupId: group.id,
+          label: group.name,
+          selected: selectedGroupId == group.id,
+        ),
+      ),
+    ];
+    return MenuEntrySubMenu<String>(
+      text: translate('Group'),
+      entries: entries,
+      padding: menuPadding,
+    );
+  }
+
+  MenuEntryBase<String> _favoriteGroupChoice({
+    required String peerId,
+    required String? groupId,
+    required String label,
+    required bool selected,
+  }) {
+    return MenuEntryButton<String>(
+      childBuilder: (TextStyle? style) => Row(
+        children: [
+          Expanded(child: Text(label, style: style)),
+          if (selected) const Icon(Icons.check, size: 16),
+        ],
+      ),
+      proc: () async {
+        favoriteGroupModel.setPeerGroup(peerId, groupId);
+        await bind.mainLoadFavPeers();
+      },
+      padding: menuPadding,
+      dismissOnClicked: true,
+    );
+  }
 }
 
 class DiscoveredPeerCard extends BasePeerCard {

--- a/flutter/lib/common/widgets/peer_tab_page.dart
+++ b/flutter/lib/common/widgets/peer_tab_page.dart
@@ -11,10 +11,12 @@ class PeerTabPage extends StatelessWidget {
     Key? key,
     this.selectedIndex,
     this.showTabs = true,
+    this.favoriteGroupId,
   }) : super(key: key);
 
   final int? selectedIndex;
   final bool showTabs;
+  final String? favoriteGroupId;
 
   @override
   Widget build(BuildContext context) {
@@ -23,7 +25,7 @@ class PeerTabPage extends StatelessWidget {
     if (!showTabs) {
       return switch (currentIndex) {
         0 => RecentPeersView(),
-        1 => FavoritePeersView(),
+        1 => FavoritePeersView(groupId: favoriteGroupId),
         _ => DiscoveredPeersView(),
       };
     }

--- a/flutter/lib/common/widgets/peers_view.dart
+++ b/flutter/lib/common/widgets/peers_view.dart
@@ -9,6 +9,7 @@ import 'package:get/get.dart';
 import 'package:provider/provider.dart';
 
 import '../../common.dart';
+import '../../models/favorite_group_model.dart';
 import '../../models/peer_model.dart';
 import '../../models/platform_model.dart';
 import 'peer_card.dart';
@@ -330,10 +331,16 @@ class RecentPeersView extends BasePeersView {
 
 class FavoritePeersView extends BasePeersView {
   FavoritePeersView(
-      {Key? key, EdgeInsets? menuPadding, ScrollController? scrollController})
+      {Key? key,
+      EdgeInsets? menuPadding,
+      ScrollController? scrollController,
+      String? groupId})
       : super(
           key: key,
           peerTabIndex: PeerTabIndex.fav,
+          peerFilter: groupId == null
+              ? null
+              : (Peer peer) => favoriteGroupModel.matches(peer.id, groupId),
           peerCardBuilder: (Peer peer) => FavoritePeerCard(
             peer: peer,
             menuPadding: menuPadding,

--- a/flutter/lib/consts.dart
+++ b/flutter/lib/consts.dart
@@ -144,6 +144,7 @@ const String kOptionPeerTabIndex = "peer-tab-index";
 const String kOptionPeerTabOrder = "peer-tab-order";
 const String kOptionPeerTabVisible = "peer-tab-visible";
 const String kOptionPeerCardUiType = "peer-card-ui-type";
+const String kOptionFavoritePeerGroups = "favorite-peer-groups";
 const String kOptionCurrentAbName = "current-ab-name";
 const String kOptionEnableConfirmClosingTabs = "enable-confirm-closing-tabs";
 const String kOptionAllowAlwaysSoftwareRender = "allow-always-software-render";

--- a/flutter/lib/desktop/pages/connection_page.dart
+++ b/flutter/lib/desktop/pages/connection_page.dart
@@ -16,6 +16,7 @@ import 'package:window_manager/window_manager.dart';
 import '../../common.dart';
 import '../../common/formatter/id_formatter.dart';
 import '../../common/widgets/peer_tab_page.dart';
+import '../../models/favorite_group_model.dart';
 import '../../models/platform_model.dart';
 import '../lan_identity_manager.dart';
 
@@ -146,10 +147,14 @@ class _OnlineStatusWidgetState extends State<OnlineStatusWidget> {
 
 /// Connection page for connecting to a remote peer.
 class ConnectionPage extends StatefulWidget {
-  const ConnectionPage({Key? key, this.selectedPeerTab = PeerTabIndex.lan})
-    : super(key: key);
+  const ConnectionPage({
+    Key? key,
+    this.selectedPeerTab = PeerTabIndex.lan,
+    this.favoriteGroupId,
+  }) : super(key: key);
 
   final PeerTabIndex selectedPeerTab;
+  final String? favoriteGroupId;
 
   @override
   State<ConnectionPage> createState() => _ConnectionPageState();
@@ -211,7 +216,8 @@ class _ConnectionPageState extends State<ConnectionPage> with WindowListener {
   @override
   void didUpdateWidget(covariant ConnectionPage oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.selectedPeerTab != widget.selectedPeerTab) {
+    if (oldWidget.selectedPeerTab != widget.selectedPeerTab ||
+        oldWidget.favoriteGroupId != widget.favoriteGroupId) {
       peerSearchText.value = '';
       peerSearchTextController.clear();
       _loadSelectedPeers();
@@ -305,9 +311,12 @@ class _ConnectionPageState extends State<ConnectionPage> with WindowListener {
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final border = isDark ? Colors.white12 : const Color(0xFFE4E8F0);
-    final sectionTitle = switch (widget.selectedPeerTab) {
+    String sectionTitle() => switch (widget.selectedPeerTab) {
       PeerTabIndex.recent => translate('Recent sessions'),
-      PeerTabIndex.fav => translate('Favorites'),
+      PeerTabIndex.fav => widget.favoriteGroupId == favoriteUngroupedId
+          ? translate('Other')
+          : favoriteGroupModel.groupById(widget.favoriteGroupId ?? '')?.name ??
+              translate('Favorites'),
       PeerTabIndex.lan => translate('Discovered'),
     };
     final peers = switch (widget.selectedPeerTab) {
@@ -415,33 +424,47 @@ class _ConnectionPageState extends State<ConnectionPage> with WindowListener {
               children: [
                 AnimatedBuilder(
                   animation: peers,
-                  builder: (context, _) => Text.rich(
-                    TextSpan(
-                      children: [
+                  builder: (context, _) => AnimatedBuilder(
+                    animation: favoriteGroupModel,
+                    builder: (context, _) {
+                      final count = widget.selectedPeerTab == PeerTabIndex.fav
+                          ? favoriteGroupModel.countForGroup(
+                              peers.peers.map((peer) => peer.id),
+                              widget.favoriteGroupId,
+                            )
+                          : peers.peers.length;
+                      return Text.rich(
                         TextSpan(
-                          text: sectionTitle,
-                          style: const TextStyle(
-                            fontSize: 20,
-                            fontWeight: FontWeight.w600,
-                          ),
+                          children: [
+                            TextSpan(
+                              text: sectionTitle(),
+                              style: const TextStyle(
+                                fontSize: 20,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                            TextSpan(
+                              text: '  ($count)',
+                              style: TextStyle(
+                                fontSize: 15,
+                                color: Theme.of(context).hintColor,
+                              ),
+                            ),
+                          ],
                         ),
-                        TextSpan(
-                          text: '  (${peers.peers.length})',
-                          style: TextStyle(
-                            fontSize: 15,
-                            color: Theme.of(context).hintColor,
-                          ),
-                        ),
-                      ],
-                    ),
+                      );
+                    },
                   ),
                 ),
                 const SizedBox(height: 14),
                 Expanded(
                   child: PeerTabPage(
-                    key: ValueKey(widget.selectedPeerTab),
+                    key: ValueKey(
+                      '${widget.selectedPeerTab.index}:${widget.favoriteGroupId ?? 'all'}',
+                    ),
                     selectedIndex: widget.selectedPeerTab.index,
                     showTabs: false,
+                    favoriteGroupId: widget.favoriteGroupId,
                   ),
                 ),
               ],

--- a/flutter/lib/desktop/pages/desktop_home_page.dart
+++ b/flutter/lib/desktop/pages/desktop_home_page.dart
@@ -11,6 +11,7 @@ import 'package:flutter_hbb/desktop/pages/desktop_setting_page.dart';
 import 'package:flutter_hbb/desktop/lan_device_name.dart';
 import 'package:flutter_hbb/desktop/lan_server_status.dart';
 import 'package:flutter_hbb/desktop/setup_readiness.dart';
+import 'package:flutter_hbb/models/favorite_group_model.dart';
 import 'package:flutter_hbb/models/platform_model.dart';
 import 'package:flutter_hbb/models/peer_tab_model.dart';
 import 'package:flutter_hbb/plugin/ui_manager.dart';
@@ -1385,6 +1386,7 @@ class _DesktopHomePageState extends State<DesktopHomePage>
   Timer? _updateTimer;
   bool isCardClosed = false;
   PeerTabIndex _selectedPeerTab = PeerTabIndex.lan;
+  String? _selectedFavoriteGroupId;
 
   final RxBool _editHover = false.obs;
   final RxBool _block = false.obs;
@@ -1401,7 +1403,14 @@ class _DesktopHomePageState extends State<DesktopHomePage>
           children: [
             _buildNavigationSidebar(context),
             const VerticalDivider(width: 1, thickness: 1),
-            Expanded(child: ConnectionPage(selectedPeerTab: _selectedPeerTab)),
+            Expanded(
+              child: ConnectionPage(
+                selectedPeerTab: _selectedPeerTab,
+                favoriteGroupId: _selectedPeerTab == PeerTabIndex.fav
+                    ? _selectedFavoriteGroupId
+                    : null,
+              ),
+            ),
           ],
         ),
       );
@@ -1511,6 +1520,8 @@ class _DesktopHomePageState extends State<DesktopHomePage>
                     label: translate('Favorites'),
                     tab: PeerTabIndex.fav,
                   ),
+                  if (_selectedPeerTab == PeerTabIndex.fav)
+                    _buildFavoriteGroupSidebar(context),
                   _buildSidebarItem(
                     context,
                     icon: Icons.settings_outlined,
@@ -2083,6 +2094,294 @@ class _DesktopHomePageState extends State<DesktopHomePage>
     );
   }
 
+  Widget _buildFavoriteGroupSidebar(BuildContext context) {
+    return AnimatedBuilder(
+      animation: favoriteGroupModel,
+      builder: (context, _) => AnimatedBuilder(
+        animation: gFFI.favoritePeersModel,
+        builder: (context, _) {
+          final favoriteIds =
+              gFFI.favoritePeersModel.peers.map((peer) => peer.id).toList();
+          return Padding(
+            padding: const EdgeInsets.fromLTRB(42, 2, 18, 8),
+            child: Column(
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        translate('Group'),
+                        style: TextStyle(
+                          color: Theme.of(context).hintColor,
+                          fontSize: 11,
+                          fontWeight: FontWeight.w600,
+                          letterSpacing: 0.4,
+                        ),
+                      ),
+                    ),
+                    IconButton(
+                      tooltip: '${translate('Add')} ${translate('Group')}',
+                      visualDensity: VisualDensity.compact,
+                      constraints:
+                          const BoxConstraints.tightFor(width: 28, height: 28),
+                      padding: EdgeInsets.zero,
+                      icon: const Icon(Icons.add_rounded, size: 17),
+                      onPressed: () => _createFavoriteGroup(context),
+                    ),
+                  ],
+                ),
+                _buildFavoriteGroupItem(
+                  context,
+                  id: null,
+                  label: translate('Select All'),
+                  count: favoriteIds.length,
+                ),
+                ...favoriteGroupModel.groups.map(
+                  (group) => _buildFavoriteGroupItem(
+                    context,
+                    id: group.id,
+                    label: group.name,
+                    count: favoriteGroupModel.countForGroup(
+                      favoriteIds,
+                      group.id,
+                    ),
+                    group: group,
+                  ),
+                ),
+                _buildFavoriteGroupItem(
+                  context,
+                  id: favoriteUngroupedId,
+                  label: translate('Other'),
+                  count: favoriteGroupModel.countForGroup(
+                    favoriteIds,
+                    favoriteUngroupedId,
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildFavoriteGroupItem(
+    BuildContext context, {
+    required String? id,
+    required String label,
+    required int count,
+    FavoriteGroup? group,
+  }) {
+    final selected = _selectedFavoriteGroupId == id;
+    final primary = Theme.of(context).colorScheme.primary;
+    final foreground = selected
+        ? primary
+        : Theme.of(context)
+            .textTheme
+            .bodyMedium
+            ?.color
+            ?.withValues(alpha: 0.68);
+    return Padding(
+      padding: const EdgeInsets.only(top: 2),
+      child: Material(
+        color: selected
+            ? primary.withValues(alpha: 0.08)
+            : Colors.transparent,
+        borderRadius: BorderRadius.circular(8),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(8),
+          onTap: () {
+            setState(() {
+              _selectedPeerTab = PeerTabIndex.fav;
+              _selectedFavoriteGroupId = id;
+            });
+          },
+          child: SizedBox(
+            height: 34,
+            child: Row(
+              children: [
+                const SizedBox(width: 10),
+                Icon(
+                  id == null
+                      ? Icons.all_inbox_outlined
+                      : id == favoriteUngroupedId
+                          ? Icons.folder_off_outlined
+                          : Icons.folder_outlined,
+                  size: 16,
+                  color: foreground,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    label,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: foreground,
+                      fontSize: 12,
+                      fontWeight:
+                          selected ? FontWeight.w600 : FontWeight.w400,
+                    ),
+                  ),
+                ),
+                Text(
+                  '$count',
+                  style: TextStyle(
+                    color: Theme.of(context).hintColor,
+                    fontSize: 11,
+                  ),
+                ),
+                if (group != null)
+                  PopupMenuButton<String>(
+                    tooltip: translate('More'),
+                    padding: EdgeInsets.zero,
+                    iconSize: 16,
+                    onSelected: (action) {
+                      if (action == 'rename') {
+                        _renameFavoriteGroup(context, group);
+                      } else if (action == 'delete') {
+                        _deleteFavoriteGroup(context, group);
+                      }
+                    },
+                    itemBuilder: (context) => [
+                      PopupMenuItem(
+                        value: 'rename',
+                        child: Text(translate('Rename')),
+                      ),
+                      PopupMenuItem(
+                        value: 'delete',
+                        child: Text(translate('Delete')),
+                      ),
+                    ],
+                  )
+                else
+                  const SizedBox(width: 10),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<String?> _showFavoriteGroupNameDialog(
+    BuildContext context, {
+    String initialValue = '',
+    String? editingGroupId,
+  }) async {
+    final formKey = GlobalKey<FormState>();
+    var currentValue = initialValue;
+    return showDialog<String>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(
+          initialValue.isEmpty
+              ? '${translate('Add')} ${translate('Group')}'
+              : '${translate('Rename')} ${translate('Group')}',
+        ),
+        content: Form(
+          key: formKey,
+          child: TextFormField(
+            initialValue: initialValue,
+            autofocus: true,
+            maxLength: 32,
+            decoration: InputDecoration(
+              labelText: '${translate('Group')} ${translate('Name')}',
+            ),
+            onChanged: (value) => currentValue = value,
+            validator: (value) {
+              final name = normalizeFavoriteGroupName(value ?? '');
+              if (name.isEmpty) {
+                return '${translate('Name')} · ${translate('Empty')}';
+              }
+              final duplicate = favoriteGroupModel.groups.any(
+                (group) =>
+                    group.id != editingGroupId &&
+                    group.name.toLowerCase() == name.toLowerCase(),
+              );
+              if (duplicate) {
+                return '${translate('Group')} ${translate('Already exists')}';
+              }
+              return null;
+            },
+            onFieldSubmitted: (value) {
+              if (formKey.currentState?.validate() == true) {
+                Navigator.of(dialogContext).pop(value);
+              }
+            },
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: Text(translate('Cancel')),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              if (formKey.currentState?.validate() == true) {
+                Navigator.of(dialogContext).pop(currentValue);
+              }
+            },
+            child: Text(translate('OK')),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _createFavoriteGroup(BuildContext context) async {
+    final name = await _showFavoriteGroupNameDialog(context);
+    if (name == null) return;
+    if (!favoriteGroupModel.createGroup(name)) {
+      showToast(translate('Already exists'));
+    }
+  }
+
+  Future<void> _renameFavoriteGroup(
+    BuildContext context,
+    FavoriteGroup group,
+  ) async {
+    final name = await _showFavoriteGroupNameDialog(
+      context,
+      initialValue: group.name,
+      editingGroupId: group.id,
+    );
+    if (name == null) return;
+    if (!favoriteGroupModel.renameGroup(group.id, name)) {
+      showToast(translate('Already exists'));
+    }
+  }
+
+  Future<void> _deleteFavoriteGroup(
+    BuildContext context,
+    FavoriteGroup group,
+  ) async {
+    final shouldDelete = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text('${translate('Delete')} ${translate('Group')}?'),
+        content: Text(group.name),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: Text(translate('Cancel')),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: Text(translate('Delete')),
+          ),
+        ],
+      ),
+    );
+    if (shouldDelete != true) return;
+
+    favoriteGroupModel.deleteGroup(group.id);
+    if (_selectedFavoriteGroupId == group.id && mounted) {
+      setState(() => _selectedFavoriteGroupId = favoriteUngroupedId);
+    }
+    await bind.mainLoadFavPeers();
+  }
+
   Widget _buildBlock({required Widget child}) {
     return buildRemoteBlock(
       block: _block,
@@ -2188,7 +2487,12 @@ class _DesktopHomePageState extends State<DesktopHomePage>
   buildRightPane(BuildContext context) {
     return Container(
       color: Theme.of(context).scaffoldBackgroundColor,
-      child: ConnectionPage(selectedPeerTab: _selectedPeerTab),
+      child: ConnectionPage(
+        selectedPeerTab: _selectedPeerTab,
+        favoriteGroupId: _selectedPeerTab == PeerTabIndex.fav
+            ? _selectedFavoriteGroupId
+            : null,
+      ),
     );
   }
 
@@ -2509,6 +2813,7 @@ class _DesktopHomePageState extends State<DesktopHomePage>
   @override
   void initState() {
     super.initState();
+    favoriteGroupModel.load();
     _updateTimer = periodic_immediate(const Duration(seconds: 1), () async {
       final error = await bind.mainGetError();
       if (systemError != error) {

--- a/flutter/lib/models/favorite_group_model.dart
+++ b/flutter/lib/models/favorite_group_model.dart
@@ -1,0 +1,215 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_hbb/consts.dart';
+import 'package:flutter_hbb/models/platform_model.dart';
+
+const String favoriteUngroupedId = '__ungrouped__';
+
+String normalizeFavoriteGroupName(String value) => value.trim();
+
+class FavoriteGroup {
+  const FavoriteGroup({required this.id, required this.name});
+
+  final String id;
+  final String name;
+
+  Map<String, String> toJson() => {'id': id, 'name': name};
+}
+
+class FavoriteGroupModel extends ChangeNotifier {
+  FavoriteGroupModel({
+    String Function()? read,
+    void Function(String value)? write,
+  }) : _read =
+           read ??
+           (() => bind.getLocalFlutterOption(k: kOptionFavoritePeerGroups)),
+       _write =
+           write ??
+           ((value) => bind.setLocalFlutterOption(
+             k: kOptionFavoritePeerGroups,
+             v: value,
+           ));
+
+  final String Function() _read;
+  final void Function(String value) _write;
+
+  final List<FavoriteGroup> _groups = [];
+  final Map<String, String> _peerGroups = {};
+  bool _loaded = false;
+  int _nextId = 0;
+
+  List<FavoriteGroup> get groups => List.unmodifiable(_groups);
+
+  void load() {
+    if (_loaded) return;
+    _loaded = true;
+
+    final raw = _read();
+    if (raw.isEmpty) return;
+
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map<String, dynamic>) {
+        throw const FormatException('favorite group data is not an object');
+      }
+
+      final groupIds = <String>{};
+      final groupNames = <String>{};
+      final rawGroups = decoded['groups'];
+      if (rawGroups is List) {
+        for (final item in rawGroups) {
+          if (item is! Map) continue;
+          final id = item['id'];
+          final name = item['name'];
+          if (id is! String || name is! String) continue;
+          final normalizedName = normalizeFavoriteGroupName(name);
+          final normalizedKey = normalizedName.toLowerCase();
+          if (id.isEmpty ||
+              normalizedName.isEmpty ||
+              groupIds.contains(id) ||
+              groupNames.contains(normalizedKey)) {
+            continue;
+          }
+          groupIds.add(id);
+          groupNames.add(normalizedKey);
+          _groups.add(FavoriteGroup(id: id, name: normalizedName));
+        }
+      }
+
+      final rawPeerGroups = decoded['peer_groups'];
+      if (rawPeerGroups is Map) {
+        for (final entry in rawPeerGroups.entries) {
+          final peerId = entry.key;
+          final groupId = entry.value;
+          if (peerId is String &&
+              peerId.isNotEmpty &&
+              groupId is String &&
+              groupIds.contains(groupId)) {
+            _peerGroups[peerId] = groupId;
+          }
+        }
+      }
+    } catch (error) {
+      _groups.clear();
+      _peerGroups.clear();
+      debugPrint('failed to load favorite peer groups: $error');
+    }
+  }
+
+  bool createGroup(String value) {
+    load();
+    final name = normalizeFavoriteGroupName(value);
+    if (name.isEmpty || name.runes.length > 32 || _containsName(name)) {
+      return false;
+    }
+
+    var id = DateTime.now().microsecondsSinceEpoch.toRadixString(36);
+    while (_groups.any((group) => group.id == id)) {
+      id = '${id}_${_nextId++}';
+    }
+    _groups.add(FavoriteGroup(id: id, name: name));
+    _saveAndNotify();
+    return true;
+  }
+
+  bool renameGroup(String id, String value) {
+    load();
+    final index = _groups.indexWhere((group) => group.id == id);
+    final name = normalizeFavoriteGroupName(value);
+    if (index < 0 ||
+        name.isEmpty ||
+        name.runes.length > 32 ||
+        _containsName(name, exceptGroupId: id)) {
+      return false;
+    }
+    if (_groups[index].name == name) return true;
+
+    _groups[index] = FavoriteGroup(id: id, name: name);
+    _saveAndNotify();
+    return true;
+  }
+
+  bool deleteGroup(String id) {
+    load();
+    if (!_groups.any((group) => group.id == id)) return false;
+    _groups.removeWhere((group) => group.id == id);
+
+    _peerGroups.removeWhere((_, groupId) => groupId == id);
+    _saveAndNotify();
+    return true;
+  }
+
+  void setPeerGroup(String peerId, String? groupId) {
+    load();
+    if (peerId.isEmpty) return;
+
+    if (groupId == null || groupId == favoriteUngroupedId) {
+      if (_peerGroups.remove(peerId) != null) {
+        _saveAndNotify();
+      }
+      return;
+    }
+    if (!_groups.any((group) => group.id == groupId) ||
+        _peerGroups[peerId] == groupId) {
+      return;
+    }
+    _peerGroups[peerId] = groupId;
+    _saveAndNotify();
+  }
+
+  void removePeer(String peerId) {
+    load();
+    if (_peerGroups.remove(peerId) != null) {
+      _saveAndNotify();
+    }
+  }
+
+  String? groupIdForPeer(String peerId) {
+    load();
+    return _peerGroups[peerId];
+  }
+
+  FavoriteGroup? groupById(String id) {
+    load();
+    for (final group in _groups) {
+      if (group.id == id) return group;
+    }
+    return null;
+  }
+
+  bool matches(String peerId, String? selectedGroupId) {
+    load();
+    if (selectedGroupId == null) return true;
+    if (selectedGroupId == favoriteUngroupedId) {
+      return !_peerGroups.containsKey(peerId);
+    }
+    return _peerGroups[peerId] == selectedGroupId;
+  }
+
+  int countForGroup(Iterable<String> favoritePeerIds, String? groupId) {
+    load();
+    return favoritePeerIds.where((peerId) => matches(peerId, groupId)).length;
+  }
+
+  bool _containsName(String name, {String? exceptGroupId}) {
+    final normalized = name.toLowerCase();
+    return _groups.any(
+      (group) =>
+          group.id != exceptGroupId && group.name.toLowerCase() == normalized,
+    );
+  }
+
+  void _saveAndNotify() {
+    _write(
+      jsonEncode({
+        'version': 1,
+        'groups': _groups.map((group) => group.toJson()).toList(),
+        'peer_groups': _peerGroups,
+      }),
+    );
+    notifyListeners();
+  }
+}
+
+final favoriteGroupModel = FavoriteGroupModel();

--- a/flutter/test/favorite_group_model_test.dart
+++ b/flutter/test/favorite_group_model_test.dart
@@ -1,0 +1,62 @@
+import 'dart:convert';
+
+import 'package:flutter_hbb/models/favorite_group_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('creates groups and assigns favorite peers', () {
+    var stored = '';
+    final model = FavoriteGroupModel(
+      read: () => stored,
+      write: (value) => stored = value,
+    );
+
+    expect(model.createGroup(' 办公室 '), isTrue);
+    expect(model.createGroup('办公室'), isFalse);
+    expect(model.createGroup('a' * 33), isFalse);
+    expect(model.groups.single.name, '办公室');
+
+    final groupId = model.groups.single.id;
+    model.setPeerGroup('peer-1', groupId);
+
+    expect(model.matches('peer-1', groupId), isTrue);
+    expect(model.matches('peer-1', favoriteUngroupedId), isFalse);
+    expect(model.countForGroup(['peer-1', 'peer-2'], groupId), 1);
+    expect(model.countForGroup(['peer-1', 'peer-2'], favoriteUngroupedId), 1);
+    expect(jsonDecode(stored)['version'], 1);
+  });
+
+  test('deleting a group keeps its peers as ungrouped favorites', () {
+    var stored = '';
+    final model = FavoriteGroupModel(
+      read: () => stored,
+      write: (value) => stored = value,
+    );
+
+    model.createGroup('服务器');
+    final groupId = model.groups.single.id;
+    model.setPeerGroup('peer-1', groupId);
+
+    expect(model.deleteGroup(groupId), isTrue);
+    expect(model.groups, isEmpty);
+    expect(model.groupIdForPeer('peer-1'), isNull);
+    expect(model.matches('peer-1', favoriteUngroupedId), isTrue);
+  });
+
+  test('loads valid data and ignores invalid group references', () {
+    final stored = jsonEncode({
+      'version': 1,
+      'groups': [
+        {'id': 'office', 'name': '办公室'},
+      ],
+      'peer_groups': {'peer-1': 'office', 'peer-2': 'missing'},
+    });
+    final model = FavoriteGroupModel(read: () => stored, write: (_) {});
+
+    model.load();
+
+    expect(model.groups.single.name, '办公室');
+    expect(model.groupIdForPeer('peer-1'), 'office');
+    expect(model.groupIdForPeer('peer-2'), isNull);
+  });
+}


### PR DESCRIPTION
## 变更内容\n\n- 在桌面端收藏夹下增加单层分组导航，提供全部、自定义分组和未分组视图\n- 支持新建、重命名、删除分组，并显示各分组设备数量\n- 在收藏设备菜单中支持移动到指定分组\n- 删除分组时保留收藏设备，并自动归入未分组\n- 取消收藏或删除设备时清理对应的分组绑定\n- 将分组和设备映射持久化到本地 Flutter 配置\n- 保留并兼容已合并的可复用 LAN 身份系统入口和连接流程\n\n## 原因\n\n收藏设备较多时缺少组织方式，用户难以快速定位办公室、服务器或其他用途的设备。\n\n## 影响\n\n桌面端收藏体验增加轻量的单层分组能力，不改变现有收藏数据；已有收藏默认显示在“未分组”中。\n\n## 验证\n\n- 重新生成 Flutter/Rust bridge 后运行 flutter test：38 项全部通过\n- 定向 flutter analyze --no-fatal-infos：无错误或警告，仅仓库既有弃用提示\n- git diff --check 通过\n\nCloses #3