### PR TITLE
fix: avoid Windows UI stalls during LAN polling

### DIFF
--- a/flutter/lib/common/widgets/peers_view.dart
+++ b/flutter/lib/common/widgets/peers_view.dart
@@ -370,8 +370,10 @@ class DiscoveredPeersView extends BasePeersView {
   @override
   Widget build(BuildContext context) {
     final widget = super.build(context);
-    bind.mainLoadLanPeers();
-    bind.mainDiscover();
+    if (!isDesktop) {
+      bind.mainLoadLanPeers();
+      bind.mainDiscover();
+    }
     return widget;
   }
 }

--- a/flutter/lib/desktop/pages/desktop_home_page.dart
+++ b/flutter/lib/desktop/pages/desktop_home_page.dart
@@ -53,6 +53,8 @@ class LanServerInfoPanel extends StatefulWidget {
 class _LanServerInfoPanelState extends State<LanServerInfoPanel> {
   Timer? _timer;
   bool _showAllAddresses = false;
+  bool _refreshing = false;
+  Map<String, dynamic> _info = <String, dynamic>{};
 
   int _addressPriority(String address) {
     final parsed = InternetAddress.tryParse(address);
@@ -75,21 +77,30 @@ class _LanServerInfoPanelState extends State<LanServerInfoPanel> {
   String _formatEndpoint(String address, String port) =>
       address.contains(':') ? '[$address]:$port' : '$address:$port';
 
-  Map<String, dynamic> get _info {
+  Future<void> _refreshInfo() async {
+    if (_refreshing) return;
+    _refreshing = true;
     try {
-      return jsonDecode(bind.mainGetLanServerInfoSync())
+      final info = jsonDecode(await bind.mainGetLanServerInfo())
           as Map<String, dynamic>;
+      if (mounted) {
+        setState(() => _info = info);
+      }
     } catch (_) {
-      return <String, dynamic>{};
+      // Keep the last successful snapshot while the host state is unavailable.
+    } finally {
+      _refreshing = false;
     }
   }
 
   @override
   void initState() {
     super.initState();
-    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
-      if (mounted) setState(() {});
-    });
+    _refreshInfo();
+    _timer = Timer.periodic(
+      const Duration(seconds: 5),
+      (_) => _refreshInfo(),
+    );
   }
 
   @override
@@ -747,7 +758,8 @@ Future<void> showLanSettingsDialog(
 }) async {
   Map<String, dynamic> info;
   try {
-    info = jsonDecode(bind.mainGetLanServerInfoSync()) as Map<String, dynamic>;
+    info = jsonDecode(await bind.mainGetLanServerInfo())
+        as Map<String, dynamic>;
   } catch (_) {
     info = <String, dynamic>{};
   }
@@ -1284,7 +1296,8 @@ Future<void> showLanSettingsDialog(
                                     try {
                                       final currentInfo =
                                           jsonDecode(
-                                                bind.mainGetLanServerInfoSync(),
+                                                await bind
+                                                    .mainGetLanServerInfo(),
                                               )
                                               as Map<String, dynamic>;
                                       final runtime =

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1664,7 +1664,15 @@ pub fn main_get_fingerprint() -> String {
     crate::lan_protocol::fingerprint(&Config::get_key_pair().1)
 }
 
+pub fn main_get_lan_server_info() -> String {
+    lan_server_info()
+}
+
 pub fn main_get_lan_server_info_sync() -> SyncReturn<String> {
+    SyncReturn(lan_server_info())
+}
+
+fn lan_server_info() -> String {
     let configured = Config::lan_credentials_configured();
     let service_stopped = config::option2bool(
         "stop-service",
@@ -1757,7 +1765,7 @@ pub fn main_get_lan_server_info_sync() -> SyncReturn<String> {
         "web_ca_certificate_path": web_ca_certificate_path,
         "web_runtime": web_runtime,
     });
-    SyncReturn(data.to_string())
+    data.to_string()
 }
 
 fn lan_server_running_for_ui(configured: bool, service_stopped: bool) -> bool {


### PR DESCRIPTION
## What changed

- move LAN server information collection onto the asynchronous Rust bridge worker instead of blocking the Dart UI thread
- cache the latest LAN server snapshot and refresh it every five seconds without overlapping requests
- stop desktop peer widgets from starting LAN discovery as a side effect of every `build()` call
- use the asynchronous query when opening and monitoring LAN settings

## Root cause

`mainGetLanServerInfoSync()` enumerated every network interface through `default_net::get_interfaces()` on the Flutter UI thread once per second. On Windows systems with several physical and virtual adapters, particularly VMware adapters, this call can take multiple seconds. Rebuilds could also repeatedly trigger mDNS discovery, compounding the delay.

The Vulkan/Impeller hypothesis from issue #13 was ruled out by the reporter's follow-up tests: copying `vulkan-1.dll` and forcing Impeller did not improve the problem.

## Impact

Network interface enumeration may still take time on affected Windows machines, but it now runs outside the Dart UI thread and cannot overlap with itself, so clicks and rendering should remain responsive.

## Validation

- `flutter test` — 38 tests passed
- targeted `flutter analyze --no-fatal-infos` — no errors; only pre-existing deprecation notices
- Rust formatting check passed
- `cargo check -p hbb_common` passed
- flutter_rust_bridge bindings generated successfully with the repository-pinned 1.80.1 generator

Full `cargo check --lib` on macOS remains blocked by the local machine missing Homebrew `libyuv`; this is unrelated to the change.

Fixes #13
