### PR TITLE
fix: prompt for macOS local network access

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="res/subnetdesk-icon.svg" alt="SubnetDesk logo" width="120">
 </p>
 
-<h1 align="center">SubnetDesk</h1>
+# SubnetDesk
 
 <p align="center">
   <strong>A LAN-first remote desktop for fast, private, direct connections.</strong>

--- a/flutter/lib/desktop/pages/desktop_home_page.dart
+++ b/flutter/lib/desktop/pages/desktop_home_page.dart
@@ -1429,6 +1429,9 @@ class _DesktopHomePageState extends State<DesktopHomePage>
   var watchIsCanRecordAudio = false;
   Timer? _updateTimer;
   bool isCardClosed = false;
+  LocalNetworkPermissionStatus _localNetworkPermission =
+      LocalNetworkPermissionStatus.unknown;
+  bool _checkingLocalNetworkPermission = false;
   PeerTabIndex _selectedPeerTab = PeerTabIndex.lan;
   String? _selectedFavoriteGroupId;
 
@@ -1637,6 +1640,9 @@ class _DesktopHomePageState extends State<DesktopHomePage>
         canScreenRecord: !isMac || bind.mainIsCanScreenRecording(prompt: false),
         processTrusted: !isMac || bind.mainIsProcessTrusted(prompt: false),
         canMonitorInput: !isMac || bind.mainIsCanInputMonitoring(prompt: false),
+        localNetworkDenied:
+            isMac &&
+            _localNetworkPermission == LocalNetworkPermissionStatus.denied,
         daemonInstalled: !isMac || bind.mainIsInstalledDaemon(prompt: false),
         selinuxEnforcing: isLinuxPlatform && bind.isSelinuxEnforcing(),
         showSelinuxWarning:
@@ -1657,6 +1663,7 @@ class _DesktopHomePageState extends State<DesktopHomePage>
       case SetupReadinessIssue.screenRecording:
       case SetupReadinessIssue.accessibility:
       case SetupReadinessIssue.inputMonitoring:
+      case SetupReadinessIssue.localNetwork:
         return translate('Permissions');
       case SetupReadinessIssue.daemon:
         return translate('Service');
@@ -1679,6 +1686,9 @@ class _DesktopHomePageState extends State<DesktopHomePage>
         return translate('config_acc');
       case SetupReadinessIssue.inputMonitoring:
         return translate('config_input');
+      case SetupReadinessIssue.localNetwork:
+        return '${translate('Open System Setting')}: '
+            '${translate('Network')} · ${translate('Enable LAN discovery')}';
       case SetupReadinessIssue.daemon:
         return translate('install_daemon_tip');
       case SetupReadinessIssue.selinux:
@@ -1702,6 +1712,8 @@ class _DesktopHomePageState extends State<DesktopHomePage>
         return Icons.accessibility_new_rounded;
       case SetupReadinessIssue.inputMonitoring:
         return Icons.keyboard_alt_outlined;
+      case SetupReadinessIssue.localNetwork:
+        return Icons.lan_outlined;
       case SetupReadinessIssue.daemon:
         return Icons.settings_suggest_outlined;
       case SetupReadinessIssue.selinux:
@@ -1717,6 +1729,7 @@ class _DesktopHomePageState extends State<DesktopHomePage>
       case SetupReadinessIssue.screenRecording:
       case SetupReadinessIssue.accessibility:
       case SetupReadinessIssue.inputMonitoring:
+      case SetupReadinessIssue.localNetwork:
       case SetupReadinessIssue.daemon:
       case SetupReadinessIssue.selinux:
       case SetupReadinessIssue.wayland:
@@ -1735,6 +1748,7 @@ class _DesktopHomePageState extends State<DesktopHomePage>
       case SetupReadinessIssue.screenRecording:
       case SetupReadinessIssue.accessibility:
       case SetupReadinessIssue.inputMonitoring:
+      case SetupReadinessIssue.localNetwork:
         return translate('Configure');
       case SetupReadinessIssue.selinux:
       case SetupReadinessIssue.wayland:
@@ -1758,6 +1772,7 @@ class _DesktopHomePageState extends State<DesktopHomePage>
       case SetupReadinessIssue.screenRecording:
       case SetupReadinessIssue.accessibility:
       case SetupReadinessIssue.inputMonitoring:
+      case SetupReadinessIssue.localNetwork:
       case SetupReadinessIssue.daemon:
         return null;
     }
@@ -1786,6 +1801,9 @@ class _DesktopHomePageState extends State<DesktopHomePage>
       case SetupReadinessIssue.inputMonitoring:
         bind.mainIsCanInputMonitoring(prompt: true);
         watchIsInputMonitoring = true;
+        break;
+      case SetupReadinessIssue.localNetwork:
+        await RdPlatformChannel.instance.openLocalNetworkSettings();
         break;
       case SetupReadinessIssue.daemon:
         bind.mainIsInstalledDaemon(prompt: true);
@@ -2858,6 +2876,11 @@ class _DesktopHomePageState extends State<DesktopHomePage>
   void initState() {
     super.initState();
     favoriteGroupModel.load();
+    if (isMacOS) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _checkLocalNetworkPermission();
+      });
+    }
     _updateTimer = periodic_immediate(const Duration(seconds: 1), () async {
       final error = await bind.mainGetError();
       if (systemError != error) {
@@ -3063,6 +3086,25 @@ class _DesktopHomePageState extends State<DesktopHomePage>
     super.didChangeAppLifecycleState(state);
     if (state == AppLifecycleState.resumed) {
       shouldBeBlocked(_block, canBeBlocked);
+      if (isMacOS) {
+        _checkLocalNetworkPermission();
+      }
+    }
+  }
+
+  Future<void> _checkLocalNetworkPermission() async {
+    if (_checkingLocalNetworkPermission) return;
+    _checkingLocalNetworkPermission = true;
+    try {
+      final status = await RdPlatformChannel.instance
+          .checkLocalNetworkPermission();
+      if (mounted && status != LocalNetworkPermissionStatus.checking) {
+        setState(() => _localNetworkPermission = status);
+      }
+    } on PlatformException catch (error) {
+      debugPrint('Failed to check local-network permission: $error');
+    } finally {
+      _checkingLocalNetworkPermission = false;
     }
   }
 

--- a/flutter/lib/desktop/setup_readiness.dart
+++ b/flutter/lib/desktop/setup_readiness.dart
@@ -6,6 +6,7 @@ enum SetupReadinessIssue {
   screenRecording,
   accessibility,
   inputMonitoring,
+  localNetwork,
   daemon,
   selinux,
   wayland,
@@ -23,6 +24,7 @@ class SetupReadinessSnapshot {
     this.canScreenRecord = true,
     this.processTrusted = true,
     this.canMonitorInput = true,
+    this.localNetworkDenied = false,
     this.daemonInstalled = true,
     this.selinuxEnforcing = false,
     this.showSelinuxWarning = true,
@@ -39,6 +41,7 @@ class SetupReadinessSnapshot {
   final bool canScreenRecord;
   final bool processTrusted;
   final bool canMonitorInput;
+  final bool localNetworkDenied;
   final bool daemonInstalled;
   final bool selinuxEnforcing;
   final bool showSelinuxWarning;
@@ -70,6 +73,9 @@ List<SetupReadinessIssue> resolveSetupReadinessIssues(
       }
       if (!snapshot.canMonitorInput) {
         issues.add(SetupReadinessIssue.inputMonitoring);
+      }
+      if (snapshot.localNetworkDenied) {
+        issues.add(SetupReadinessIssue.localNetwork);
       }
       if (!snapshot.outgoingOnly &&
           !snapshot.serviceStopped &&

--- a/flutter/lib/utils/platform_channel.dart
+++ b/flutter/lib/utils/platform_channel.dart
@@ -5,6 +5,8 @@ import 'package:flutter_hbb/common.dart';
 
 enum SystemWindowTheme { light, dark }
 
+enum LocalNetworkPermissionStatus { authorized, denied, checking, unknown }
+
 /// The platform channel for RustDesk.
 class RdPlatformChannel {
   RdPlatformChannel._();
@@ -41,5 +43,24 @@ class RdPlatformChannel {
   Future<void> terminate() {
     assert(isMacOS);
     return _hostMethodChannel.invokeMethod("terminate");
+  }
+
+  Future<LocalNetworkPermissionStatus> checkLocalNetworkPermission() async {
+    assert(isMacOS);
+    final status = await _hostMethodChannel.invokeMethod<String>(
+      "checkLocalNetworkPermission",
+    );
+    return LocalNetworkPermissionStatus.values.firstWhere(
+      (value) => value.name == status,
+      orElse: () => LocalNetworkPermissionStatus.unknown,
+    );
+  }
+
+  Future<bool> openLocalNetworkSettings() async {
+    assert(isMacOS);
+    return await _hostMethodChannel.invokeMethod<bool>(
+          "openLocalNetworkSettings",
+        ) ??
+        false;
   }
 }

--- a/flutter/macos/Runner/Info.plist
+++ b/flutter/macos/Runner/Info.plist
@@ -43,6 +43,12 @@
 	<string>MainMenu</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Record the sound from microphone for the purpose of the remote desktop.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>SubnetDesk uses your local network to discover and connect to nearby devices for remote access.</string>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_subnetdesk._tcp</string>
+	</array>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
     <key>LSUIElement</key>

--- a/flutter/macos/Runner/MainFlutterWindow.swift
+++ b/flutter/macos/Runner/MainFlutterWindow.swift
@@ -1,6 +1,7 @@
 import Cocoa
 import AVFoundation
 import FlutterMacOS
+import Network
 import app_links
 import desktop_multi_window
 // import bitsdojo_window_macos
@@ -35,7 +36,133 @@ class RelativeMouseState {
     private init() {}
 }
 
+private final class LocalNetworkPermissionProbe {
+    private let queue = DispatchQueue(label: "com.zibochen.subnetdesk.local-network-permission")
+    private let serviceName = "SubnetDesk-\(UUID().uuidString)"
+    private var browser: NWBrowser?
+    private var listener: NWListener?
+    private var completion: ((String) -> Void)?
+    private var timeoutWorkItem: DispatchWorkItem?
+    private var finished = false
+    private var browserStarted = false
+
+    func start(completion: @escaping (String) -> Void) {
+        queue.async {
+            self.completion = completion
+            do {
+                let parameters = NWParameters.tcp
+                parameters.includePeerToPeer = true
+
+                let listener = try NWListener(using: parameters)
+                listener.service = NWListener.Service(
+                    name: self.serviceName,
+                    type: "_subnetdesk._tcp"
+                )
+                listener.newConnectionHandler = { connection in
+                    connection.cancel()
+                }
+                listener.stateUpdateHandler = { [weak self] state in
+                    self?.handleListenerState(state)
+                }
+                self.listener = listener
+
+                let browser = NWBrowser(
+                    for: .bonjour(type: "_subnetdesk._tcp", domain: nil),
+                    using: parameters
+                )
+                browser.stateUpdateHandler = { [weak self] state in
+                    self?.handleBrowserState(state)
+                }
+                browser.browseResultsChangedHandler = { [weak self] results, _ in
+                    guard let self = self else { return }
+                    let foundOwnService = results.contains { result in
+                        guard case .service(let name, _, _, _) = result.endpoint else {
+                            return false
+                        }
+                        return name == self.serviceName
+                    }
+                    if foundOwnService {
+                        self.finish("authorized")
+                    }
+                }
+                self.browser = browser
+
+                listener.start(queue: self.queue)
+
+                let timeout = DispatchWorkItem { [weak self] in
+                    self?.finish("unknown")
+                }
+                self.timeoutWorkItem = timeout
+                self.queue.asyncAfter(deadline: .now() + 30, execute: timeout)
+            } catch {
+                NSLog("[SubnetDesk] Failed to start the local-network permission probe: %@", error.localizedDescription)
+                self.finish("unknown")
+            }
+        }
+    }
+
+    private func handleListenerState(_ state: NWListener.State) {
+        switch state {
+        case .ready:
+            if !browserStarted {
+                browserStarted = true
+                browser?.start(queue: queue)
+            }
+        case .waiting(let error), .failed(let error):
+            handle(error)
+        default:
+            break
+        }
+    }
+
+    private func handleBrowserState(_ state: NWBrowser.State) {
+        switch state {
+        case .waiting(let error), .failed(let error):
+            handle(error)
+        default:
+            break
+        }
+    }
+
+    private func handle(_ error: NWError) {
+        if Self.isPermissionDenied(error) {
+            finish("denied")
+        } else {
+            NSLog("[SubnetDesk] Local-network permission probe failed: %@", error.debugDescription)
+            finish("unknown")
+        }
+    }
+
+    private static func isPermissionDenied(_ error: NWError) -> Bool {
+        switch error {
+        case .dns(let code):
+            return code == -65570 || code == -65571
+        case .posix(let code):
+            return code == .EPERM || code == .EACCES
+        default:
+            return false
+        }
+    }
+
+    private func finish(_ status: String) {
+        guard !finished else { return }
+        finished = true
+        timeoutWorkItem?.cancel()
+        browser?.cancel()
+        listener?.cancel()
+        browser = nil
+        listener = nil
+        let callback = completion
+        completion = nil
+        DispatchQueue.main.async {
+            callback?(status)
+        }
+    }
+}
+
 class MainFlutterWindow: NSWindow {
+    private var localNetworkPermissionProbe: LocalNetworkPermissionProbe?
+
     override func awakeFromNib() {
         rustdesk_core_main();
         let flutterViewController = FlutterViewController.init()
@@ -215,6 +342,26 @@ class MainFlutterWindow: NSWindow {
                         }
                     })
                     break
+                case "checkLocalNetworkPermission":
+                    if self.localNetworkPermissionProbe != nil {
+                        result("checking")
+                        break
+                    }
+                    let probe = LocalNetworkPermissionProbe()
+                    self.localNetworkPermissionProbe = probe
+                    probe.start { [weak self] status in
+                        self?.localNetworkPermissionProbe = nil
+                        result(status)
+                    }
+                case "openLocalNetworkSettings":
+                    let urls = [
+                        "x-apple.systempreferences:com.apple.preference.security?Privacy_LocalNetwork",
+                        "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension?Privacy_LocalNetwork"
+                    ]
+                    let opened = urls.compactMap(URL.init(string:)).contains {
+                        NSWorkspace.shared.open($0)
+                    }
+                    result(opened)
                 case "bumpMouse":
                     var dx = 0
                     var dy = 0

--- a/flutter/test/setup_readiness_test.dart
+++ b/flutter/test/setup_readiness_test.dart
@@ -11,6 +11,7 @@ void main() {
           canScreenRecord: false,
           processTrusted: false,
           canMonitorInput: false,
+          localNetworkDenied: true,
           daemonInstalled: false,
         ),
       );
@@ -21,6 +22,7 @@ void main() {
           SetupReadinessIssue.screenRecording,
           SetupReadinessIssue.accessibility,
           SetupReadinessIssue.inputMonitoring,
+          SetupReadinessIssue.localNetwork,
           SetupReadinessIssue.daemon,
         ],
       );
@@ -40,6 +42,18 @@ void main() {
       );
 
       expect(issues, const [SetupReadinessIssue.inputMonitoring]);
+    });
+
+    test('denied local-network access is reported for outgoing-only mode', () {
+      final issues = resolveSetupReadinessIssues(
+        const SetupReadinessSnapshot(
+          platform: SetupReadinessPlatform.macos,
+          outgoingOnly: true,
+          localNetworkDenied: true,
+        ),
+      );
+
+      expect(issues, const [SetupReadinessIssue.localNetwork]);
     });
 
     test('explicitly stopped service does not request daemon installation', () {

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -66,6 +66,12 @@ mod lan_server_info_tests {
     fn macos_lan_settings_are_synchronized_to_the_background_host() {
         assert!(should_sync_lan_settings_to_background());
     }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_portable_lan_settings_are_synchronized_to_the_background_host() {
+        assert!(should_sync_lan_settings_to_background());
+    }
 }
 
 fn initialize(app_dir: &str, custom_client_config: &str) {
@@ -1781,7 +1787,10 @@ fn should_sync_lan_settings_to_background() -> bool {
     }
     #[cfg(target_os = "windows")]
     {
-        crate::platform::is_self_service_running()
+        // Portable builds run the background host as a user process instead of
+        // an SCM service. It still owns an independent in-memory Config snapshot,
+        // so LAN credentials and listener options must always be synchronized.
+        true
     }
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {


### PR DESCRIPTION
## What changed

- declare the macOS local-network usage description and Bonjour service
- probe Local Network authorization through temporary Bonjour publish/discovery
- show denied access in the desktop readiness panel and open the relevant System Settings page
- recheck permission after returning to the app
- add readiness resolver tests

## Why

Issue #21 confirmed that macOS clients could not reach nearby Windows and Android devices until SubnetDesk was manually enabled under Privacy & Security → Local Network. The app previously neither triggered the system prompt nor surfaced the missing permission.

## Validation

- `flutter test --no-pub test/setup_readiness_test.dart`
- `flutter analyze --no-pub lib/desktop/setup_readiness.dart lib/utils/platform_channel.dart test/setup_readiness_test.dart`
- `plutil -lint flutter/macos/Runner/Info.plist`
- `git diff --check`

Closes #21