### PR TITLE
fix: restore Windows portable remote activation

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -3067,7 +3067,7 @@ Future<void> start_service(bool is_start) async {
       !isMacOS ||
       await callMainCheckSuperUserPermission();
   if (checked) {
-    mainSetBoolOption(kOptionStopService, !is_start);
+    await mainSetBoolOption(kOptionStopService, !is_start);
   }
 }
 

--- a/flutter/lib/desktop/lan_server_status.dart
+++ b/flutter/lib/desktop/lan_server_status.dart
@@ -21,3 +21,20 @@ LanServerDisplayStatus lanServerDisplayStatus({
   }
   return LanServerDisplayStatus.serviceStopped;
 }
+
+bool shouldOfferRemoteActivation({
+  required bool configured,
+  required bool lanServerRunning,
+  required bool windowsPortable,
+  required bool portableServiceRunning,
+}) {
+  return configured &&
+      (!lanServerRunning || (windowsPortable && !portableServiceRunning));
+}
+
+bool shouldOfferPortableInstall({
+  required bool windowsPortable,
+  required bool installationDisabled,
+}) {
+  return windowsPortable && !installationDisabled;
+}

--- a/flutter/lib/desktop/pages/desktop_home_page.dart
+++ b/flutter/lib/desktop/pages/desktop_home_page.dart
@@ -54,6 +54,7 @@ class _LanServerInfoPanelState extends State<LanServerInfoPanel> {
   Timer? _timer;
   bool _showAllAddresses = false;
   bool _refreshing = false;
+  bool _activatingRemote = false;
   Map<String, dynamic> _info = <String, dynamic>{};
 
   int _addressPriority(String address) {
@@ -114,6 +115,19 @@ class _LanServerInfoPanelState extends State<LanServerInfoPanel> {
     final info = _info;
     final configured = info['configured'] == true;
     final running = info['running'] == true;
+    final windowsPortable = isWindows && !bind.mainIsInstalled();
+    final portableServiceRunning =
+        info['portable_service_running'] == true;
+    final offerRemoteActivation = shouldOfferRemoteActivation(
+      configured: configured,
+      lanServerRunning: running,
+      windowsPortable: windowsPortable,
+      portableServiceRunning: portableServiceRunning,
+    );
+    final offerPortableInstall = shouldOfferPortableInstall(
+      windowsPortable: windowsPortable,
+      installationDisabled: bind.isDisableInstallation(),
+    );
     final runtimeError = info['runtime_error']?.toString() ?? '';
     final displayStatus = lanServerDisplayStatus(
       configured: configured,
@@ -303,6 +317,14 @@ class _LanServerInfoPanelState extends State<LanServerInfoPanel> {
                   ),
                 ),
               ],
+              if (offerRemoteActivation || offerPortableInstall) ...[
+                const SizedBox(height: 9),
+                _buildRemoteActions(
+                  windowsPortable: windowsPortable,
+                  offerRemoteActivation: offerRemoteActivation,
+                  offerPortableInstall: offerPortableInstall,
+                ),
+              ],
               const SizedBox(height: 12),
               Divider(
                 height: 1,
@@ -438,6 +460,14 @@ class _LanServerInfoPanelState extends State<LanServerInfoPanel> {
                   color: Theme.of(context).colorScheme.error,
                   fontSize: 11,
                 ),
+              ),
+            ],
+            if (offerRemoteActivation || offerPortableInstall) ...[
+              const SizedBox(height: 10),
+              _buildRemoteActions(
+                windowsPortable: windowsPortable,
+                offerRemoteActivation: offerRemoteActivation,
+                offerPortableInstall: offerPortableInstall,
               ),
             ],
             const SizedBox(height: 14),
@@ -590,6 +620,58 @@ class _LanServerInfoPanelState extends State<LanServerInfoPanel> {
         ),
       ),
     );
+  }
+
+  Widget _buildRemoteActions({
+    required bool windowsPortable,
+    required bool offerRemoteActivation,
+    required bool offerPortableInstall,
+  }) {
+    return Wrap(
+      spacing: 8,
+      runSpacing: 6,
+      children: [
+        if (offerRemoteActivation)
+          OutlinedButton.icon(
+            onPressed: _activatingRemote ? null : _enableRemote,
+            icon: _activatingRemote
+                ? const SizedBox(
+                    width: 14,
+                    height: 14,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.power_settings_new_rounded, size: 16),
+            label: Text(
+              windowsPortable
+                  ? '${translate('Enable')} ${translate('Remote')}'
+                  : translate('Start service'),
+            ),
+          ),
+        if (offerPortableInstall)
+          TextButton.icon(
+            onPressed: _openInstaller,
+            icon: const Icon(Icons.download_for_offline_outlined, size: 16),
+            label: Text(translate('Install')),
+          ),
+      ],
+    );
+  }
+
+  Future<void> _enableRemote() async {
+    if (_activatingRemote) return;
+    setState(() => _activatingRemote = true);
+    try {
+      await start_service(true);
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      await _refreshInfo();
+    } finally {
+      if (mounted) setState(() => _activatingRemote = false);
+    }
+  }
+
+  Future<void> _openInstaller() async {
+    await rustDeskWinManager.closeAllSubWindows();
+    bind.mainGotoInstall();
   }
 
   Widget _buildCompactInfoRow({

--- a/flutter/test/lan_server_status_test.dart
+++ b/flutter/test/lan_server_status_test.dart
@@ -33,4 +33,57 @@ void main() {
       LanServerDisplayStatus.serviceFailed,
     );
   });
+
+  test('Windows portable mode offers elevation when LAN is stopped', () {
+    expect(
+      shouldOfferRemoteActivation(
+        configured: true,
+        lanServerRunning: false,
+        windowsPortable: true,
+        portableServiceRunning: false,
+      ),
+      isTrue,
+    );
+  });
+
+  test('Windows portable mode can elevate even when user LAN is ready', () {
+    expect(
+      shouldOfferRemoteActivation(
+        configured: true,
+        lanServerRunning: true,
+        windowsPortable: true,
+        portableServiceRunning: false,
+      ),
+      isTrue,
+    );
+  });
+
+  test('remote activation is hidden after portable service starts', () {
+    expect(
+      shouldOfferRemoteActivation(
+        configured: true,
+        lanServerRunning: true,
+        windowsPortable: true,
+        portableServiceRunning: true,
+      ),
+      isFalse,
+    );
+  });
+
+  test('portable installation remains a separate supported action', () {
+    expect(
+      shouldOfferPortableInstall(
+        windowsPortable: true,
+        installationDisabled: false,
+      ),
+      isTrue,
+    );
+    expect(
+      shouldOfferPortableInstall(
+        windowsPortable: true,
+        installationDisabled: true,
+      ),
+      isFalse,
+    );
+  });
 }

--- a/src/flutter_ffi.rs
+++ b/src/flutter_ffi.rs
@@ -1692,6 +1692,10 @@ pub fn main_get_lan_server_info_sync() -> SyncReturn<String> {
 
 fn lan_server_info() -> String {
     let configured = Config::lan_credentials_configured();
+    #[cfg(target_os = "windows")]
+    let portable_service_running = crate::portable_service::client::running();
+    #[cfg(not(target_os = "windows"))]
+    let portable_service_running = false;
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     let (runtime_state, runtime_error) = get_lan_server_runtime_status();
     #[cfg(any(target_os = "android", target_os = "ios"))]
@@ -1749,6 +1753,7 @@ fn lan_server_info() -> String {
     let data = serde_json::json!({
         "configured": configured,
         "running": running,
+        "portable_service_running": portable_service_running,
         "runtime_state": runtime_state,
         "runtime_error": runtime_error,
         "username": Config::get_lan_access_username(),

--- a/src/ui_interface.rs
+++ b/src/ui_interface.rs
@@ -368,6 +368,27 @@ pub fn set_options(m: HashMap<String, String>) {
     Config::set_options(m);
 }
 
+#[cfg(any(target_os = "windows", test))]
+fn should_start_portable_service(is_installed: bool, value: &str, running: bool) -> bool {
+    !is_installed && value != "Y" && !running
+}
+
+#[cfg(target_os = "windows")]
+fn start_portable_service_if_needed(value: &str) {
+    if !should_start_portable_service(
+        crate::platform::is_installed(),
+        value,
+        crate::portable_service::client::running(),
+    ) {
+        return;
+    }
+    if let Err(err) = crate::portable_service::client::start_portable_service(
+        crate::portable_service::client::StartPara::Direct,
+    ) {
+        log::warn!("Failed to start Windows portable service: {err}");
+    }
+}
+
 #[inline]
 pub fn set_option(key: String, value: String) {
     if &key == "stop-service" {
@@ -392,6 +413,8 @@ pub fn set_option(key: String, value: String) {
                 }
                 return;
             }
+            #[cfg(target_os = "windows")]
+            start_portable_service_if_needed(&value);
         }
     } else if &key == "audio-input" {
         #[cfg(not(target_os = "ios"))]
@@ -410,6 +433,19 @@ pub fn set_option(key: String, value: String) {
     #[cfg(any(target_os = "android", target_os = "ios"))]
     {
         Config::set_option(key, value);
+    }
+}
+
+#[cfg(test)]
+mod portable_service_tests {
+    use super::should_start_portable_service;
+
+    #[test]
+    fn portable_windows_enable_requests_elevation() {
+        assert!(should_start_portable_service(false, "", false));
+        assert!(!should_start_portable_service(false, "Y", false));
+        assert!(!should_start_portable_service(true, "", false));
+        assert!(!should_start_portable_service(false, "", true));
     }
 }
 


### PR DESCRIPTION
## What changed

- restore an **Enable Remote** action in the LAN host status card
- start the existing Windows portable-service elevation chain when an uninstalled portable build enables the service
- keep **Install** as a separate action that opens the full installer
- expose portable-service runtime state to Flutter so the elevation action disappears after the temporary service is ready
- await the service option update and add decision-logic tests

## Root cause

The redesigned desktop UI no longer rendered the normal-mode `OnlineStatusWidget`, so a portable Windows user could see **Service is not running** without a start action. The remaining service toggle only cleared `stop-service`; because the app was not installed, the Rust path skipped SCM installation and never started `portable_service`, so no UAC prompt was shown.

## Validation

- `flutter test --no-pub test/lan_server_status_test.dart test/setup_readiness_test.dart` (16 tests passed)
- `flutter analyze --no-pub --no-fatal-infos lib/desktop/lan_server_status.dart lib/desktop/pages/desktop_home_page.dart lib/common.dart test/lan_server_status_test.dart` (no errors or warnings; existing info-level deprecations only)
- `bash scripts/check_lan_only_residuals.sh`
- `bash scripts/check_subnetdesk_branding.sh`
- `git diff --check`

Local Rust test compilation remains blocked by the existing missing Homebrew `libyuv` dependency; Windows CI will compile and validate the platform-specific path.