### PR TITLE
Fix LAN device labels and VPN Web access

### DIFF
--- a/flutter/lib/common.dart
+++ b/flutter/lib/common.dart
@@ -9,6 +9,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_hbb/common/formatter/id_formatter.dart';
+import 'package:flutter_hbb/desktop/peer_tab_label.dart';
 import 'package:flutter_hbb/desktop/widgets/refresh_wrapper.dart';
 import 'package:flutter_hbb/desktop/widgets/tabbar_widget.dart';
 import 'package:flutter_hbb/main.dart';
@@ -3219,21 +3220,21 @@ Widget buildErrorBanner(
 }
 
 String getDesktopTabLabel(String peerId, String alias) {
-  String label = alias.isEmpty ? peerId : alias;
+  String hostname = '';
   try {
     String peer = bind.mainGetPeerSync(id: peerId);
     Map<String, dynamic> config = jsonDecode(peer);
     if (config['info']['hostname'] is String) {
-      String hostname = config['info']['hostname'];
-      if (hostname.isNotEmpty &&
-          !label.toLowerCase().contains(hostname.toLowerCase())) {
-        label += "@$hostname";
-      }
+      hostname = config['info']['hostname'];
     }
   } catch (e) {
     debugPrint("Failed to get hostname:$e");
   }
-  return label;
+  return composePeerTabLabel(
+    peerId: peerId,
+    alias: alias,
+    hostname: hostname,
+  );
 }
 
 sessionRefreshVideo(SessionID sessionId, PeerInfo pi) async {

--- a/flutter/lib/desktop/pages/desktop_home_page.dart
+++ b/flutter/lib/desktop/pages/desktop_home_page.dart
@@ -1235,7 +1235,7 @@ Future<void> showLanSettingsDialog(
                                 label: 'Web listen addresses',
                                 icon: Icons.dns_outlined,
                                 help:
-                                    'Comma-separated IP addresses. Blank falls back to the native LAN listener.',
+                                    'Comma-separated IP addresses. Blank falls back to the native LAN listener. VPN addresses outside the default private ranges also require a matching Web allowed network.',
                               ),
                             ),
                             const SizedBox(height: 10),
@@ -1245,7 +1245,7 @@ Future<void> showLanSettingsDialog(
                                 label: 'Web allowed networks',
                                 icon: Icons.security_rounded,
                                 help:
-                                    'Comma-separated CIDR ranges. Blank falls back to the native LAN policy.',
+                                    'Comma-separated CIDR ranges. Blank falls back to the native LAN policy. Add the VPN CIDR here when an overlay network uses public-looking addresses.',
                               ),
                             ),
                             const SizedBox(height: 10),

--- a/flutter/lib/desktop/peer_tab_label.dart
+++ b/flutter/lib/desktop/peer_tab_label.dart
@@ -1,0 +1,17 @@
+String composePeerTabLabel({
+  required String peerId,
+  required String alias,
+  required String hostname,
+}) {
+  final normalizedAlias = alias.trim();
+  if (normalizedAlias.isNotEmpty) {
+    return normalizedAlias;
+  }
+
+  final normalizedHostname = hostname.trim();
+  if (normalizedHostname.isNotEmpty) {
+    return normalizedHostname;
+  }
+
+  return peerId;
+}

--- a/flutter/test/lan_device_name_test.dart
+++ b/flutter/test/lan_device_name_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_hbb/desktop/lan_device_name.dart';
 import 'package:flutter_hbb/desktop/lan_discovery_refresh.dart';
+import 'package:flutter_hbb/desktop/peer_tab_label.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -42,6 +43,41 @@ void main() {
           windowMinimized: true,
         ),
         isFalse,
+      );
+    });
+  });
+
+  group('peer tab label', () {
+    test('prefers the local alias', () {
+      expect(
+        composePeerTabLabel(
+          peerId: '192.168.1.10:21118',
+          alias: '  客厅平板  ',
+          hostname: '08',
+        ),
+        '客厅平板',
+      );
+    });
+
+    test('uses the remote device name when no alias exists', () {
+      expect(
+        composePeerTabLabel(
+          peerId: '192.168.1.10:21118',
+          alias: '',
+          hostname: '08',
+        ),
+        '08',
+      );
+    });
+
+    test('falls back to the peer address', () {
+      expect(
+        composePeerTabLabel(
+          peerId: '192.168.1.10:21118',
+          alias: ' ',
+          hostname: ' ',
+        ),
+        '192.168.1.10:21118',
       );
     });
   });

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -11,6 +11,8 @@ use crate::clipboard::try_empty_clipboard_files;
 use crate::clipboard::{update_clipboard, ClipboardSide};
 #[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
 use crate::clipboard_file::*;
+#[cfg(any(target_os = "android", target_os = "ios"))]
+use crate::flutter::connection_manager::start_channel;
 #[cfg(target_os = "android")]
 use crate::keyboard::client::map_key_to_control_key;
 #[cfg(target_os = "linux")]
@@ -25,8 +27,6 @@ use crate::{
     },
     display_service, ipc, privacy_mode, video_service, VERSION,
 };
-#[cfg(any(target_os = "android", target_os = "ios"))]
-use crate::{common::DEVICE_NAME, flutter::connection_manager::start_channel};
 #[cfg(target_os = "android")]
 use hbb_common::protobuf::EnumOrUnknown;
 use hbb_common::{
@@ -1274,6 +1274,7 @@ impl Connection {
         let mut username = crate::platform::get_active_username();
         let mut res = LoginResponse::new();
         let mut pi = PeerInfo {
+            hostname: crate::lan::device_display_name(),
             username: username.clone(),
             version: VERSION.to_owned(),
             ..Default::default()
@@ -1281,12 +1282,10 @@ impl Connection {
 
         #[cfg(not(target_os = "android"))]
         {
-            pi.hostname = crate::whoami_hostname();
             pi.platform = hbb_common::whoami::platform().to_string();
         }
         #[cfg(target_os = "android")]
         {
-            pi.hostname = DEVICE_NAME.lock().unwrap().clone();
             pi.platform = "Android".into();
         }
         #[cfg(all(target_os = "macos", not(feature = "unix-file-copy-paste")))]

--- a/src/web_gateway.rs
+++ b/src/web_gateway.rs
@@ -610,32 +610,59 @@ fn validate_custom_certificate_identity(certificate: &[u8]) -> ResultType<()> {
     Ok(())
 }
 
-fn certificate_subject_alt_names() -> Vec<String> {
+fn build_certificate_subject_alt_names(
+    configured_hosts: &str,
+    listen_addresses: &[IpAddr],
+    interface_addresses: &[IpAddr],
+) -> Vec<String> {
     let mut names = vec!["localhost".to_owned(), "subnetdesk.local".to_owned()];
     names.extend(
-        Config::get_option("web-allowed-hosts")
+        configured_hosts
             .split(',')
             .filter_map(|value| normalize_configured_host(value).ok()),
     );
+    names.extend(
+        listen_addresses
+            .iter()
+            .filter(|address| !address.is_unspecified())
+            .map(ToString::to_string),
+    );
+    names.extend(interface_addresses.iter().map(ToString::to_string));
+    names.sort();
+    names.dedup();
+    names
+}
+
+fn certificate_subject_alt_names() -> Vec<String> {
+    let listen_addresses = match configured_addresses() {
+        Ok(addresses) => addresses,
+        Err(error) => {
+            log::warn!("Failed to include Web listen addresses in certificate: {error}");
+            Vec::new()
+        }
+    };
+    let mut interface_addresses = Vec::new();
     for interface in default_net::get_interfaces() {
-        names.extend(
+        interface_addresses.extend(
             interface
                 .ipv4
                 .into_iter()
                 .filter(|network| web_source_allowed(IpAddr::V4(network.addr)))
-                .map(|network| network.addr.to_string()),
+                .map(|network| IpAddr::V4(network.addr)),
         );
-        names.extend(
+        interface_addresses.extend(
             interface
                 .ipv6
                 .into_iter()
                 .filter(|network| web_source_allowed(IpAddr::V6(network.addr)))
-                .map(|network| network.addr.to_string()),
+                .map(|network| IpAddr::V6(network.addr)),
         );
     }
-    names.sort();
-    names.dedup();
-    names
+    build_certificate_subject_alt_names(
+        &Config::get_option("web-allowed-hosts"),
+        &listen_addresses,
+        &interface_addresses,
+    )
 }
 
 pub(crate) fn certificate_address_signature() -> Vec<String> {
@@ -1303,8 +1330,23 @@ async fn restrict_request(
         .get::<ConnectInfo<SocketAddr>>()
         .map(|connect| connect.0.ip());
     let authority = request_authority(request.headers(), request.uri()).unwrap_or_default();
-    if !source_allowed || !authority_host_allowed(authority, &state.allowed_hosts) {
-        return (StatusCode::FORBIDDEN, "Forbidden").into_response();
+    if !source_allowed {
+        log::warn!(
+            "Rejected Web request from {}: source is outside the allowed networks",
+            source
+                .map(|address| address.to_string())
+                .unwrap_or_else(|| "unknown source".to_owned())
+        );
+        return (StatusCode::FORBIDDEN, "Source address is not allowed").into_response();
+    }
+    if !authority_host_allowed(authority, &state.allowed_hosts) {
+        log::warn!(
+            "Rejected Web request from {} for disallowed Host {authority}",
+            source
+                .map(|address| address.to_string())
+                .unwrap_or_else(|| "unknown source".to_owned())
+        );
+        return (StatusCode::FORBIDDEN, "Host is not allowed").into_response();
     }
     if !source
         .map(|source| state.request_budget.lock().unwrap().allow(source))
@@ -1675,6 +1717,17 @@ mod tests {
             HashSet::from(["192.168.1.20".to_owned()])
         );
         assert!(configured_allowed_hosts("user@desk.example", Vec::new()).is_err());
+    }
+
+    #[test]
+    fn explicit_vpn_listener_is_an_implicit_host_and_certificate_name() {
+        let vpn_address = "110.110.110.164".parse::<IpAddr>().unwrap();
+        let names = build_certificate_subject_alt_names("", &[vpn_address], &[]);
+
+        assert!(names.contains(&vpn_address.to_string()));
+        assert!(configured_allowed_hosts("", names)
+            .unwrap()
+            .contains(&vpn_address.to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- report the configured LAN device name during login and prefer aliases/device names in desktop tab labels
- include explicit Web/VPN listen addresses in generated certificate SANs and implicit Host validation
- return actionable Web access denial reasons and document the VPN allowed-network requirement
- add regression tests for peer tab labels and explicit VPN listener host/certificate coverage

## Validation

- `flutter test test/lan_device_name_test.dart` — passed (7 tests)
- `flutter analyze --no-pub lib/desktop/peer_tab_label.dart test/lan_device_name_test.dart` — passed
- `rustfmt --edition 2021 --check src/server/connection.rs src/web_gateway.rs` — passed
- `git diff --check` — passed
- targeted Rust test was attempted, but local compilation is blocked by the repository build script requiring an unavailable `/opt/homebrew/Cellar/libyuv`; the regression test is included for CI

Fixes #27
Fixes #29