### PR TITLE
Fix Windows UI texture lifecycle stalls

### DIFF
--- a/flutter/lib/desktop/pages/remote_page.dart
+++ b/flutter/lib/desktop/pages/remote_page.dart
@@ -341,24 +341,22 @@ class _RemotePageState extends State<RemotePage>
   }
 
   @override
-  Future<void> dispose() async {
+  void dispose() {
     final closeSession = closeSessionOnDispose.remove(widget.id) ?? true;
+    final id = widget.id;
 
-    // https://github.com/flutter/flutter/issues/64935
-    super.dispose();
-    debugPrint("REMOTE PAGE dispose session $sessionId ${widget.id}");
+    debugPrint("REMOTE PAGE dispose session $sessionId $id");
 
     // Defensive cleanup: ensure host system-key propagation is reset even if
     // MouseRegion.onExit never fired (e.g., tab closed while cursor inside).
     if (!isWeb) bind.hostStopSystemKeyPropagate(stopped: true);
 
+    _ffi.canvasModel.disposeEdgeScroll();
     _pointerLockCenterDebounceTimer?.cancel();
     _pointerLockCenterDebounceTimer = null;
     _waylandKeyboardModeWorker?.dispose();
     // Clear callback reference to prevent memory leaks and stale references
     _ffi.inputModel.onRelativeMouseModeDisabled = null;
-    // Relative mouse mode cleanup is centralized in FFI.close(closeSession: ...).
-    _ffi.textureModel.onRemotePageDispose(closeSession);
     if (closeSession) {
       // ensure we leave this session, this is a double check
       _ffi.inputModel.enterOrLeave(false);
@@ -368,19 +366,58 @@ class _RemotePageState extends State<RemotePage>
     _ffi.imageModel.disposeImage();
     _ffi.cursorModel.disposeImages();
     _rawKeyFocusNode.dispose();
+    _timer?.cancel();
     if (closeSession) {
       clearWaylandKeyboardPromptSuppressedForConnection(sessionId.toString());
     }
-    await _ffi.close(closeSession: closeSession);
-    _timer?.cancel();
+    WakelockManager.disable(_uniqueKey);
+    super.dispose();
+
+    unawaited(_disposeSession(closeSession, id));
+  }
+
+  Future<void> _disposeSession(bool closeSession, String id) async {
+    // Stop native rendering before closing the session so no decoder thread can
+    // keep writing to a texture that is being unregistered.
+    try {
+      await _ffi.textureModel.onRemotePageDispose();
+    } catch (e, stack) {
+      debugPrint('Failed to dispose remote textures for $id: $e');
+      debugPrintStack(stackTrace: stack);
+    }
+    try {
+      await _ffi.close(closeSession: closeSession);
+    } catch (e, stack) {
+      debugPrint('Failed to close remote session $id: $e');
+      debugPrintStack(stackTrace: stack);
+    }
     _ffi.dialogManager.dismissAll();
     if (closeSession) {
-      await SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,
-          overlays: SystemUiOverlay.values);
+      try {
+        await SystemChrome.setEnabledSystemUIMode(
+          SystemUiMode.manual,
+          overlays: SystemUiOverlay.values,
+        );
+      } catch (e, stack) {
+        debugPrint('Failed to restore system UI for $id: $e');
+        debugPrintStack(stackTrace: stack);
+      }
     }
-    WakelockManager.disable(_uniqueKey);
-    await Get.delete<FFI>(tag: widget.id);
-    removeSharedStates(widget.id);
+    var ownsRegistration = false;
+    try {
+      ownsRegistration = Get.isRegistered<FFI>(tag: id) &&
+          identical(Get.find<FFI>(tag: id), _ffi);
+      if (ownsRegistration) {
+        await Get.delete<FFI>(tag: id);
+      }
+    } catch (e, stack) {
+      debugPrint('Failed to delete remote session model $id: $e');
+      debugPrintStack(stackTrace: stack);
+    } finally {
+      if (ownsRegistration) {
+        removeSharedStates(id);
+      }
+    }
   }
 
   Widget emptyOverlay() => BlockableOverlay(

--- a/flutter/lib/desktop/pages/view_camera_page.dart
+++ b/flutter/lib/desktop/pages/view_camera_page.dart
@@ -207,13 +207,11 @@ class _ViewCameraPageState extends State<ViewCameraPage>
   }
 
   @override
-  Future<void> dispose() async {
+  void dispose() {
     final closeSession = closeSessionOnDispose.remove(widget.id) ?? true;
+    final id = widget.id;
 
-    // https://github.com/flutter/flutter/issues/64935
-    super.dispose();
-    debugPrint("VIEW CAMERA PAGE dispose session $sessionId ${widget.id}");
-    _ffi.textureModel.onViewCameraPageDispose(closeSession);
+    debugPrint("VIEW CAMERA PAGE dispose session $sessionId $id");
     if (closeSession) {
       // ensure we leave this session, this is a double check
       _ffi.inputModel.enterOrLeave(false);
@@ -223,16 +221,53 @@ class _ViewCameraPageState extends State<ViewCameraPage>
     _ffi.imageModel.disposeImage();
     _ffi.cursorModel.disposeImages();
     _rawKeyFocusNode.dispose();
-    await _ffi.close(closeSession: closeSession);
     _timer?.cancel();
+    WakelockManager.disable(_uniqueKey);
+    super.dispose();
+
+    unawaited(_disposeSession(closeSession, id));
+  }
+
+  Future<void> _disposeSession(bool closeSession, String id) async {
+    try {
+      await _ffi.textureModel.onViewCameraPageDispose();
+    } catch (e, stack) {
+      debugPrint('Failed to dispose camera textures for $id: $e');
+      debugPrintStack(stackTrace: stack);
+    }
+    try {
+      await _ffi.close(closeSession: closeSession);
+    } catch (e, stack) {
+      debugPrint('Failed to close camera session $id: $e');
+      debugPrintStack(stackTrace: stack);
+    }
     _ffi.dialogManager.dismissAll();
     if (closeSession) {
-      await SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,
-          overlays: SystemUiOverlay.values);
+      try {
+        await SystemChrome.setEnabledSystemUIMode(
+          SystemUiMode.manual,
+          overlays: SystemUiOverlay.values,
+        );
+      } catch (e, stack) {
+        debugPrint('Failed to restore system UI for $id: $e');
+        debugPrintStack(stackTrace: stack);
+      }
     }
-    WakelockManager.disable(_uniqueKey);
-    await Get.delete<FFI>(tag: widget.id);
-    removeSharedStates(widget.id);
+    var ownsRegistration = false;
+    try {
+      ownsRegistration = Get.isRegistered<FFI>(tag: id) &&
+          identical(Get.find<FFI>(tag: id), _ffi);
+      if (ownsRegistration) {
+        await Get.delete<FFI>(tag: id);
+      }
+    } catch (e, stack) {
+      debugPrint('Failed to delete camera session model $id: $e');
+      debugPrintStack(stackTrace: stack);
+    } finally {
+      if (ownsRegistration) {
+        removeSharedStates(id);
+      }
+    }
   }
 
   Widget emptyOverlay() => BlockableOverlay(

--- a/flutter/lib/models/desktop_render_texture.dart
+++ b/flutter/lib/models/desktop_render_texture.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gpu_texture_renderer/flutter_gpu_texture_renderer.dart';
 import 'package:flutter_hbb/common/shared_state.dart';
@@ -15,43 +17,73 @@ class _PixelbufferTexture {
   int _textureKey = -1;
   int _display = 0;
   SessionID? _sessionId;
-  bool _destroying = false;
+  bool _destroyRequested = false;
+  int _ptr = 0;
   int? _id;
+  Future<void>? _createFuture;
+  Future<void>? _destroyFuture;
 
   final textureRenderer = TextureRgbaRenderer();
 
   int get display => _display;
 
-  create(int d, SessionID sessionId, FFI ffi) {
+  void create(int d, SessionID sessionId, FFI ffi) {
     _display = d;
     _textureKey = bind.getNextTextureKey();
     _sessionId = sessionId;
-
-    textureRenderer.createTexture(_textureKey).then((id) async {
-      _id = id;
-      if (id != -1) {
-        ffi.textureModel.setRgbaTextureId(display: d, id: id);
-        final ptr = await textureRenderer.getTexturePtr(_textureKey);
-        platformFFI.registerPixelbufferTexture(sessionId, display, ptr);
-        debugPrint(
-            "create pixelbuffer texture: peerId: ${ffi.id} display:$_display, textureId:$id, texturePtr:$ptr");
-      }
-    });
+    _createFuture = _create(ffi, _textureKey);
   }
 
-  destroy(bool unregisterTexture, FFI ffi) async {
-    if (!_destroying && _textureKey != -1 && _sessionId != null) {
-      _destroying = true;
-      if (unregisterTexture) {
-        platformFFI.registerPixelbufferTexture(_sessionId!, display, 0);
-        // sleep for a while to avoid the texture is used after it's unregistered.
-        await Future.delayed(Duration(milliseconds: 100));
-      }
-      await textureRenderer.closeTexture(_textureKey);
-      _textureKey = -1;
-      _destroying = false;
+  Future<void> _create(FFI ffi, int textureKey) async {
+    try {
+      final id = await textureRenderer.createTexture(textureKey);
+      _id = id;
+      if (id == -1 || _destroyRequested) return;
+
+      ffi.textureModel.setRgbaTextureId(display: display, id: id);
+      final ptr = await textureRenderer.getTexturePtr(textureKey);
+      if (_destroyRequested || ptr == 0) return;
+
+      final sessionId = _sessionId;
+      if (sessionId == null) return;
+      platformFFI.registerPixelbufferTexture(sessionId, display, ptr);
+      _ptr = ptr;
       debugPrint(
-          "destroy pixelbuffer texture: peerId: ${ffi.id} display:$_display, textureId:$_id");
+        "create pixelbuffer texture: peerId: ${ffi.id} display:$_display, textureId:$id, texturePtr:$ptr",
+      );
+    } catch (e, stack) {
+      debugPrint('Failed to create pixelbuffer texture: $e');
+      debugPrintStack(stackTrace: stack);
+    }
+  }
+
+  Future<void> destroy(FFI ffi) {
+    return _destroyFuture ??= _destroy(ffi);
+  }
+
+  Future<void> _destroy(FFI ffi) async {
+    _destroyRequested = true;
+    await _createFuture;
+
+    final textureKey = _textureKey;
+    final sessionId = _sessionId;
+    if (textureKey == -1 || sessionId == null) return;
+
+    if (_ptr != 0) {
+      platformFFI.unregisterPixelbufferTexture(sessionId, display, _ptr);
+      _ptr = 0;
+    }
+    try {
+      await textureRenderer.closeTexture(textureKey);
+    } catch (e, stack) {
+      debugPrint('Failed to destroy pixelbuffer texture: $e');
+      debugPrintStack(stackTrace: stack);
+    } finally {
+      _textureKey = -1;
+      _sessionId = null;
+      debugPrint(
+        "destroy pixelbuffer texture: peerId: ${ffi.id} display:$_display, textureId:$_id",
+      );
     }
   }
 }
@@ -60,10 +92,12 @@ class _GpuTexture {
   int _textureId = -1;
   SessionID? _sessionId;
   final support = bind.mainHasGpuTextureRender();
-  bool _destroying = false;
+  bool _destroyRequested = false;
   int _display = 0;
   int? _id;
   int? _output;
+  Future<void>? _createFuture;
+  Future<void>? _destroyFuture;
 
   int get display => _display;
 
@@ -71,44 +105,66 @@ class _GpuTexture {
 
   _GpuTexture();
 
-  create(int d, SessionID sessionId, FFI ffi) {
+  void create(int d, SessionID sessionId, FFI ffi) {
     if (support) {
       _sessionId = sessionId;
       _display = d;
-
-      gpuTextureRenderer.registerTexture().then((id) async {
-        _id = id;
-        if (id != null) {
-          _textureId = id;
-          ffi.textureModel.setGpuTextureId(display: d, id: id);
-          final output = await gpuTextureRenderer.output(id);
-          _output = output;
-          if (output != null) {
-            platformFFI.registerGpuTexture(sessionId, d, output);
-          }
-          debugPrint(
-              "create gpu texture: peerId: ${ffi.id} display:$_display, textureId:$id, output:$output");
-        }
-      }, onError: (err) {
-        debugPrint("Failed to register gpu texture:$err");
-      });
+      _createFuture = _create(ffi);
     }
   }
 
-  destroy(bool unregisterTexture, FFI ffi) async {
-    // must stop texture render, render unregistered texture cause crash
-    if (!_destroying && support && _sessionId != null && _textureId != -1) {
-      _destroying = true;
-      if (unregisterTexture) {
-        platformFFI.registerGpuTexture(_sessionId!, _display, 0);
-        // sleep for a while to avoid the texture is used after it's unregistered.
-        await Future.delayed(Duration(milliseconds: 100));
-      }
-      await gpuTextureRenderer.unregisterTexture(_textureId);
-      _textureId = -1;
-      _destroying = false;
+  Future<void> _create(FFI ffi) async {
+    try {
+      final id = await gpuTextureRenderer.registerTexture();
+      _id = id;
+      if (id == null) return;
+      _textureId = id;
+      if (_destroyRequested) return;
+
+      ffi.textureModel.setGpuTextureId(display: display, id: id);
+      final output = await gpuTextureRenderer.output(id);
+      _output = output;
+      if (_destroyRequested || output == null) return;
+
+      final sessionId = _sessionId;
+      if (sessionId == null) return;
+      platformFFI.registerGpuTexture(sessionId, display, output);
       debugPrint(
-          "destroy gpu texture: peerId: ${ffi.id} display:$_display, textureId:$_id, output:$_output");
+        "create gpu texture: peerId: ${ffi.id} display:$_display, textureId:$id, output:$output",
+      );
+    } catch (e, stack) {
+      debugPrint('Failed to create gpu texture: $e');
+      debugPrintStack(stackTrace: stack);
+    }
+  }
+
+  Future<void> destroy(FFI ffi) {
+    return _destroyFuture ??= _destroy(ffi);
+  }
+
+  Future<void> _destroy(FFI ffi) async {
+    _destroyRequested = true;
+    await _createFuture;
+
+    final sessionId = _sessionId;
+    if (!support || sessionId == null || _textureId == -1) return;
+
+    final output = _output;
+    if (output != null) {
+      platformFFI.unregisterGpuTexture(sessionId, display, output);
+      _output = null;
+    }
+    try {
+      await gpuTextureRenderer.unregisterTexture(_textureId);
+    } catch (e, stack) {
+      debugPrint('Failed to destroy gpu texture: $e');
+      debugPrintStack(stackTrace: stack);
+    } finally {
+      _textureId = -1;
+      _sessionId = null;
+      debugPrint(
+        "destroy gpu texture: peerId: ${ffi.id} display:$_display, textureId:$_id, output:$output",
+      );
     }
   }
 }
@@ -144,10 +200,13 @@ class TextureModel {
   final Map<int, _Control> _control = {};
   final Map<int, _PixelbufferTexture> _pixelbufferRenderTextures = {};
   final Map<int, _GpuTexture> _gpuRenderTextures = {};
+  bool _destroying = false;
+  Future<void>? _destroyFuture;
 
   TextureModel(this.parent);
 
   setTextureType({required int display, required bool gpuTexture}) {
+    if (_destroying) return;
     debugPrint("setTextureType: display=$display, isGpuTexture=$gpuTexture");
     ensureControl(display);
     _control[display]?.setTextureType(gpuTexture: gpuTexture);
@@ -181,7 +240,7 @@ class TextureModel {
   }
 
   updateCurrentDisplay(int curDisplay) {
-    if (isWeb) return;
+    if (isWeb || _destroying) return;
     final ffi = parent.target;
     if (ffi == null) return;
     tryCreateTexture(int idx) {
@@ -200,11 +259,11 @@ class TextureModel {
     tryRemoveTexture(int idx) {
       _control.remove(idx);
       if (_pixelbufferRenderTextures.containsKey(idx)) {
-        _pixelbufferRenderTextures[idx]!.destroy(true, ffi);
+        unawaited(_pixelbufferRenderTextures[idx]!.destroy(ffi));
         _pixelbufferRenderTextures.remove(idx);
       }
       if (_gpuRenderTextures.containsKey(idx)) {
-        _gpuRenderTextures[idx]!.destroy(true, ffi);
+        unawaited(_gpuRenderTextures[idx]!.destroy(ffi));
         _gpuRenderTextures.remove(idx);
       }
     }
@@ -224,26 +283,29 @@ class TextureModel {
     }
   }
 
-  onRemotePageDispose(bool closeSession) async {
+  Future<void> _destroyAll() async {
+    _destroying = true;
     final ffi = parent.target;
     if (ffi == null) return;
-    for (final texture in _pixelbufferRenderTextures.values) {
-      await texture.destroy(closeSession, ffi);
+    final pixelbufferTextures = _pixelbufferRenderTextures.values.toList();
+    final gpuTextures = _gpuRenderTextures.values.toList();
+    for (final texture in pixelbufferTextures) {
+      await texture.destroy(ffi);
     }
-    for (final texture in _gpuRenderTextures.values) {
-      await texture.destroy(closeSession, ffi);
+    for (final texture in gpuTextures) {
+      await texture.destroy(ffi);
     }
+    _pixelbufferRenderTextures.clear();
+    _gpuRenderTextures.clear();
+    _control.clear();
   }
 
-  onViewCameraPageDispose(bool closeSession) async {
-    final ffi = parent.target;
-    if (ffi == null) return;
-    for (final texture in _pixelbufferRenderTextures.values) {
-      await texture.destroy(closeSession, ffi);
-    }
-    for (final texture in _gpuRenderTextures.values) {
-      await texture.destroy(closeSession, ffi);
-    }
+  Future<void> onRemotePageDispose() {
+    return _destroyFuture ??= _destroyAll();
+  }
+
+  Future<void> onViewCameraPageDispose() {
+    return _destroyFuture ??= _destroyAll();
   }
 
   ensureControl(int display) {

--- a/flutter/lib/models/model.dart
+++ b/flutter/lib/models/model.dart
@@ -2250,6 +2250,10 @@ class EdgeScrollFallbackState {
   void stop() {
     _ticker.stop();
   }
+
+  void dispose() {
+    _ticker.dispose();
+  }
 }
 
 class CanvasModel with ChangeNotifier {
@@ -2604,6 +2608,11 @@ class CanvasModel with ChangeNotifier {
 
   void cancelEdgeScroll() {
     _edgeScrollFallbackState.stop();
+  }
+
+  void disposeEdgeScroll() {
+    _edgeScrollState = EdgeScrollState.inactive;
+    _edgeScrollFallbackState.dispose();
   }
 
   (Vector2, Vector2) getScrollInfo() {

--- a/flutter/lib/models/native_model.dart
+++ b/flutter/lib/models/native_model.dart
@@ -23,6 +23,8 @@ final class RgbaFrame extends Struct {
 
 typedef F3 = Pointer<Uint8> Function(Pointer<Utf8>, int);
 typedef F3Dart = Pointer<Uint8> Function(Pointer<Utf8>, Int32);
+typedef UnregisterTexture = Void Function(Pointer<Utf8>, UintPtr, UintPtr);
+typedef UnregisterTextureDart = void Function(Pointer<Utf8>, int, int);
 typedef HandleEvent = Future<void> Function(Map<String, dynamic> evt);
 
 /// FFI wrapper around the native Rust core.
@@ -43,6 +45,8 @@ class PlatformFFI {
 
   RustdeskImpl get ffiBind => _ffiBind;
   F3? _session_get_rgba;
+  UnregisterTextureDart? _session_unregister_pixelbuffer_texture;
+  UnregisterTextureDart? _session_unregister_gpu_texture;
 
   static get localeName => Platform.localeName;
 
@@ -114,6 +118,28 @@ class PlatformFFI {
   void registerGpuTexture(SessionID sessionId, int display, int ptr) =>
       _ffiBind.sessionRegisterGpuTexture(
           sessionId: sessionId, display: display, ptr: ptr);
+  void unregisterPixelbufferTexture(
+      SessionID sessionId, int display, int ptr) {
+    final unregister = _session_unregister_pixelbuffer_texture;
+    if (unregister == null) return;
+    final sessionIdStr = sessionId.toString().toNativeUtf8();
+    try {
+      unregister(sessionIdStr, display, ptr);
+    } finally {
+      malloc.free(sessionIdStr);
+    }
+  }
+
+  void unregisterGpuTexture(SessionID sessionId, int display, int ptr) {
+    final unregister = _session_unregister_gpu_texture;
+    if (unregister == null) return;
+    final sessionIdStr = sessionId.toString().toNativeUtf8();
+    try {
+      unregister(sessionIdStr, display, ptr);
+    } finally {
+      malloc.free(sessionIdStr);
+    }
+  }
 
   /// Init the FFI class, loads the native Rust core library.
   Future<void> init(String appType) async {
@@ -134,6 +160,12 @@ class PlatformFFI {
     debugPrint('initializing FFI $_appType');
     try {
       _session_get_rgba = dylib.lookupFunction<F3Dart, F3>("session_get_rgba");
+      _session_unregister_pixelbuffer_texture = dylib.lookupFunction<
+          UnregisterTexture, UnregisterTextureDart>(
+        "session_unregister_pixelbuffer_texture",
+      );
+      _session_unregister_gpu_texture = dylib.lookupFunction<UnregisterTexture,
+          UnregisterTextureDart>("session_unregister_gpu_texture");
       try {
         // SYSTEM user failed
         _dir = (await getApplicationDocumentsDirectory()).path;

--- a/flutter/lib/models/web_model.dart
+++ b/flutter/lib/models/web_model.dart
@@ -108,6 +108,9 @@ class PlatformFFI {
   void registerGpuTexture(SessionID sessionId, int display, int ptr) =>
       _ffiBind.sessionRegisterGpuTexture(
           sessionId: sessionId, display: display, ptr: ptr);
+  void unregisterPixelbufferTexture(
+      SessionID sessionId, int display, int ptr) {}
+  void unregisterGpuTexture(SessionID sessionId, int display, int ptr) {}
 
   Future<void> init(String appType) async {
     Completer completer = Completer();

--- a/flutter/pubspec.lock
+++ b/flutter/pubspec.lock
@@ -573,8 +573,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "08a471bb8ceccdd50483c81cdfa8b81b07b14b87"
-      resolved-ref: "08a471bb8ceccdd50483c81cdfa8b81b07b14b87"
+      ref: "208619e750a5fd904c689a9babd6ccf0f7c1ca88"
+      resolved-ref: "208619e750a5fd904c689a9babd6ccf0f7c1ca88"
       url: "https://github.com/rustdesk-org/flutter_gpu_texture_renderer"
     source: git
     version: "0.0.1"
@@ -1378,8 +1378,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "42797e0f03141dc2b585f76c64a13974508058b4"
-      resolved-ref: "42797e0f03141dc2b585f76c64a13974508058b4"
+      ref: "883326ddd4fb2af1484bf873b4ea856a0ac440bc"
+      resolved-ref: "883326ddd4fb2af1484bf873b4ea856a0ac440bc"
       url: "https://github.com/rustdesk-org/flutter_texture_rgba_renderer"
     source: git
     version: "0.0.16"

--- a/flutter/pubspec.yaml
+++ b/flutter/pubspec.yaml
@@ -83,13 +83,13 @@ dependencies:
   texture_rgba_renderer:
     git:
       url: https://github.com/rustdesk-org/flutter_texture_rgba_renderer
-      ref: 42797e0f03141dc2b585f76c64a13974508058b4
+      ref: 883326ddd4fb2af1484bf873b4ea856a0ac440bc
   percent_indicator: ^4.2.2
   dropdown_button2: ^2.0.0
   flutter_gpu_texture_renderer:
     git:
       url: https://github.com/rustdesk-org/flutter_gpu_texture_renderer
-      ref: 08a471bb8ceccdd50483c81cdfa8b81b07b14b87
+      ref: 208619e750a5fd904c689a9babd6ccf0f7c1ca88
   uuid: ^3.0.7
   auto_size_text_field: ^2.2.1
   flex_color_picker: ^3.3.0

--- a/src/flutter.rs
+++ b/src/flutter.rs
@@ -426,6 +426,24 @@ impl VideoRenderer {
         }
     }
 
+    fn unregister_pixelbuffer_texture(&self, display: usize, ptr: usize) {
+        if ptr == 0 {
+            return;
+        }
+        let mut sessions_lock = self.map_display_sessions.write().unwrap();
+        if let Some(info) = sessions_lock.get_mut(&display) {
+            if info.texture_rgba_ptr != ptr as TextureRgbaPtr {
+                return;
+            }
+            info.texture_rgba_ptr = usize::default();
+            #[cfg(feature = "vram")]
+            if info.gpu_output_ptr != usize::default() {
+                return;
+            }
+            sessions_lock.remove(&display);
+        }
+    }
+
     #[cfg(feature = "vram")]
     pub fn register_gpu_output(&self, display: usize, ptr: usize) {
         let mut sessions_lock = self.map_display_sessions.write().unwrap();
@@ -463,6 +481,24 @@ impl VideoRenderer {
                     );
                 }
             }
+        }
+    }
+
+    #[cfg(feature = "vram")]
+    pub fn unregister_gpu_output(&self, display: usize, ptr: usize) {
+        if ptr == 0 {
+            return;
+        }
+        let mut sessions_lock = self.map_display_sessions.write().unwrap();
+        if let Some(info) = sessions_lock.get_mut(&display) {
+            if info.gpu_output_ptr != ptr {
+                return;
+            }
+            info.gpu_output_ptr = usize::default();
+            if info.texture_rgba_ptr != usize::default() {
+                return;
+            }
+            sessions_lock.remove(&display);
         }
     }
 
@@ -1836,6 +1872,59 @@ pub fn session_register_gpu_texture(_session_id: SessionID, _display: usize, _ou
             break;
         }
     }
+}
+
+#[no_mangle]
+pub extern "C" fn session_unregister_pixelbuffer_texture(
+    session_uuid_str: *const char,
+    display: usize,
+    ptr: usize,
+) {
+    let Ok(session_id) = char_to_session_id(session_uuid_str) else {
+        return;
+    };
+    for session in sessions::get_sessions() {
+        if let Some(handler) = session
+            .ui_handler
+            .session_handlers
+            .read()
+            .unwrap()
+            .get(&session_id)
+        {
+            handler
+                .renderer
+                .unregister_pixelbuffer_texture(display, ptr);
+            break;
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn session_unregister_gpu_texture(
+    session_uuid_str: *const char,
+    display: usize,
+    ptr: usize,
+) {
+    #[cfg(feature = "vram")]
+    {
+        let Ok(session_id) = char_to_session_id(session_uuid_str) else {
+            return;
+        };
+        for session in sessions::get_sessions() {
+            if let Some(handler) = session
+                .ui_handler
+                .session_handlers
+                .read()
+                .unwrap()
+                .get(&session_id)
+            {
+                handler.renderer.unregister_gpu_output(display, ptr);
+                break;
+            }
+        }
+    }
+    #[cfg(not(feature = "vram"))]
+    let _ = (session_uuid_str, display, ptr);
 }
 
 #[inline]


### PR DESCRIPTION
## Summary
- dispose edge-scroll tickers and page resources synchronously
- serialize RGBA/GPU texture creation and destruction
- compare-and-clear native texture pointers during tab/window migration
- update texture renderer plugins to lifetime-safe revisions

## Local validation
- Flutter tests: 45 passed
- cargo check --lib --features flutter: passed
- rustfmt and diff checks: passed

The branch is based directly on master and contains only the Windows UI lifecycle fix.