### PR TITLE
Fix LAN trust fallback and release identities

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -48,6 +48,7 @@ env:
   NDK_VERSION: "r28c"
   #signing keys env variable checks
   ANDROID_SIGNING_KEY: "${{ secrets.ANDROID_SIGNING_KEY }}"
+  ANDROID_SIGNING_CERT_SHA256: "${{ secrets.ANDROID_SIGNING_CERT_SHA256 }}"
   MACOS_P12_BASE64: "${{ secrets.MACOS_P12_BASE64 }}"
   UPLOAD_ARTIFACT: "${{ inputs.upload-artifact }}"
   PUBLISH_RELEASE: "${{ inputs.publish-release }}"
@@ -1073,7 +1074,7 @@ jobs:
           export PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH
           # Increase Gradle JVM memory for CI builds
           sed -i "s/org.gradle.jvmargs=-Xmx1024M/org.gradle.jvmargs=-Xmx2g/g" ./flutter/android/gradle.properties
-          # temporary use debug sign config
+          # Use a temporary build signature; the APK is re-signed and fingerprint-verified below.
           sed -i "s/signingConfigs.release/signingConfigs.debug/g" ./flutter/android/app/build.gradle
           case ${{ matrix.job.target }} in
             aarch64-linux-android)
@@ -1125,6 +1126,27 @@ jobs:
           echo "ANDROID_SIGN_TOOL_VERSION=$BUILD_TOOL_VERSION" >> $GITHUB_ENV
           echo Last build tool version is: $BUILD_TOOL_VERSION
 
+      - name: Require fixed Android signing identity for releases
+        if: env.PUBLISH_RELEASE == 'true'
+        shell: bash
+        env:
+          ANDROID_ALIAS: ${{ secrets.ANDROID_ALIAS }}
+          ANDROID_KEY_STORE_PASSWORD: ${{ secrets.ANDROID_KEY_STORE_PASSWORD }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          for value in \
+            "$ANDROID_SIGNING_KEY" \
+            "$ANDROID_ALIAS" \
+            "$ANDROID_KEY_STORE_PASSWORD" \
+            "$ANDROID_KEY_PASSWORD" \
+            "$ANDROID_SIGNING_CERT_SHA256"
+          do
+            if [ -z "$value" ]; then
+              echo "Android release signing secrets are incomplete; refusing to publish." >&2
+              exit 1
+            fi
+          done
+
       - uses: r0adkll/sign-android-release@349ebdef58775b1e0d8099458af0816dc79b6407 # v1
         name: Sign app APK
         if: env.ANDROID_SIGNING_KEY != ''
@@ -1138,6 +1160,29 @@ jobs:
         env:
           # env.ANDROID_SIGN_TOOL_VERSION is set by Step "Setup sign tool version variable"
           BUILD_TOOLS_VERSION: ${{ env.ANDROID_SIGN_TOOL_VERSION }}
+
+      - name: Verify fixed Android signing certificate
+        if: env.ANDROID_SIGNING_KEY != ''
+        shell: bash
+        env:
+          SIGNED_APK: ${{ steps.sign-rustdesk.outputs.signedReleaseFile }}
+        run: |
+          expected=$(printf '%s' "$ANDROID_SIGNING_CERT_SHA256" | tr '[:lower:]' '[:upper:]' | tr -d ': ')
+          if ! printf '%s' "$expected" | grep -Eq '^[0-9A-F]{64}$'; then
+            echo "ANDROID_SIGNING_CERT_SHA256 must contain one SHA-256 certificate fingerprint." >&2
+            exit 1
+          fi
+          actual=$("$ANDROID_HOME/build-tools/$ANDROID_SIGN_TOOL_VERSION/apksigner" verify --print-certs "$SIGNED_APK" \
+            | sed -n 's/^Signer #1 certificate SHA-256 digest: //p' \
+            | head -n 1 \
+            | tr '[:lower:]' '[:upper:]' \
+            | tr -d ': ')
+          if [ "$actual" != "$expected" ]; then
+            echo "Android signing certificate does not match the pinned fingerprint." >&2
+            echo "Expected: $expected" >&2
+            echo "Actual:   $actual" >&2
+            exit 1
+          fi
 
       - name: Upload Artifacts
         if: env.ANDROID_SIGNING_KEY != '' && env.UPLOAD_ARTIFACT == 'true'
@@ -1155,16 +1200,6 @@ jobs:
           tag_name: ${{ env.TAG_NAME }}
           files: |
             ${{steps.sign-rustdesk.outputs.signedReleaseFile}}
-
-      - name: Publish unsigned apk package
-        if: env.ANDROID_SIGNING_KEY == '' && env.PUBLISH_RELEASE == 'true'
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
-        with:
-          prerelease: ${{ inputs.upload-tag == 'nightly' || contains(inputs.upload-tag, '-') }}
-          generate_release_notes: true
-          tag_name: ${{ env.TAG_NAME }}
-          files: |
-            signed-apk/subnetdesk-${{ env.VERSION }}-${{ matrix.job.arch }}.apk
 
   build-rustdesk-android-universal:
     needs: [build-rustdesk-android]
@@ -1279,7 +1314,7 @@ jobs:
           export PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH
           # Increase Gradle JVM memory for CI builds
           sed -i "s/org.gradle.jvmargs=-Xmx1024M/org.gradle.jvmargs=-Xmx2g/g" ./flutter/android/gradle.properties
-          # temporary use debug sign config
+          # Use a temporary build signature; the APK is re-signed and fingerprint-verified below.
           sed -i "s/signingConfigs.release/signingConfigs.debug/g" ./flutter/android/app/build.gradle
           mv ./flutter/android/app/src/main/jniLibs/arm64-v8a/liblibrustdesk.so ./flutter/android/app/src/main/jniLibs/arm64-v8a/librustdesk.so
           cp ${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so ./flutter/android/app/src/main/jniLibs/arm64-v8a/
@@ -1306,6 +1341,27 @@ jobs:
           echo "ANDROID_SIGN_TOOL_VERSION=$BUILD_TOOL_VERSION" >> $GITHUB_ENV
           echo Last build tool version is: $BUILD_TOOL_VERSION
 
+      - name: Require fixed Android signing identity for releases
+        if: env.PUBLISH_RELEASE == 'true'
+        shell: bash
+        env:
+          ANDROID_ALIAS: ${{ secrets.ANDROID_ALIAS }}
+          ANDROID_KEY_STORE_PASSWORD: ${{ secrets.ANDROID_KEY_STORE_PASSWORD }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          for value in \
+            "$ANDROID_SIGNING_KEY" \
+            "$ANDROID_ALIAS" \
+            "$ANDROID_KEY_STORE_PASSWORD" \
+            "$ANDROID_KEY_PASSWORD" \
+            "$ANDROID_SIGNING_CERT_SHA256"
+          do
+            if [ -z "$value" ]; then
+              echo "Android release signing secrets are incomplete; refusing to publish." >&2
+              exit 1
+            fi
+          done
+
       - uses: r0adkll/sign-android-release@349ebdef58775b1e0d8099458af0816dc79b6407 # v1
         name: Sign app APK
         if: env.ANDROID_SIGNING_KEY != ''
@@ -1319,6 +1375,29 @@ jobs:
         env:
           # env.ANDROID_SIGN_TOOL_VERSION is set by Step "Setup sign tool version variable"
           BUILD_TOOLS_VERSION: ${{ env.ANDROID_SIGN_TOOL_VERSION }}
+
+      - name: Verify fixed Android signing certificate
+        if: env.ANDROID_SIGNING_KEY != ''
+        shell: bash
+        env:
+          SIGNED_APK: ${{ steps.sign-rustdesk.outputs.signedReleaseFile }}
+        run: |
+          expected=$(printf '%s' "$ANDROID_SIGNING_CERT_SHA256" | tr '[:lower:]' '[:upper:]' | tr -d ': ')
+          if ! printf '%s' "$expected" | grep -Eq '^[0-9A-F]{64}$'; then
+            echo "ANDROID_SIGNING_CERT_SHA256 must contain one SHA-256 certificate fingerprint." >&2
+            exit 1
+          fi
+          actual=$("$ANDROID_HOME/build-tools/$ANDROID_SIGN_TOOL_VERSION/apksigner" verify --print-certs "$SIGNED_APK" \
+            | sed -n 's/^Signer #1 certificate SHA-256 digest: //p' \
+            | head -n 1 \
+            | tr '[:lower:]' '[:upper:]' \
+            | tr -d ': ')
+          if [ "$actual" != "$expected" ]; then
+            echo "Android signing certificate does not match the pinned fingerprint." >&2
+            echo "Expected: $expected" >&2
+            echo "Actual:   $actual" >&2
+            exit 1
+          fi
 
       - name: Upload Artifacts
         if: env.ANDROID_SIGNING_KEY != '' && env.UPLOAD_ARTIFACT == 'true'
@@ -1336,16 +1415,6 @@ jobs:
           tag_name: ${{ env.TAG_NAME }}
           files: |
             ${{steps.sign-rustdesk.outputs.signedReleaseFile}}
-
-      - name: Publish unsigned apk package
-        if: env.ANDROID_SIGNING_KEY == '' && env.PUBLISH_RELEASE == 'true'
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
-        with:
-          prerelease: ${{ inputs.upload-tag == 'nightly' || contains(inputs.upload-tag, '-') }}
-          generate_release_notes: true
-          tag_name: ${{ env.TAG_NAME }}
-          files: |
-            signed-apk/subnetdesk-${{ env.VERSION }}-universal${{ env.suffix }}.apk
 
   build-rustdesk-linux:
     needs: [generate-bridge]

--- a/.github/workflows/subnetdesk-preflight.yml
+++ b/.github/workflows/subnetdesk-preflight.yml
@@ -59,6 +59,12 @@ jobs:
             grep -Fq "$artifact" .github/workflows/flutter-build.yml
           done
 
+      - name: Check Android signing contract
+        run: |
+          grep -Fq 'ANDROID_SIGNING_CERT_SHA256' .github/workflows/flutter-build.yml
+          grep -Fq 'Verify fixed Android signing certificate' .github/workflows/flutter-build.yml
+          ! grep -Fq 'Publish unsigned apk package' .github/workflows/flutter-build.yml
+
       - name: Check release upload retry contract
         run: bash scripts/check_release_upload_retry.sh
 

--- a/docs/android-signing.md
+++ b/docs/android-signing.md
@@ -1,0 +1,47 @@
+# Android release signing
+
+SubnetDesk release APKs must always use the same Android signing certificate. The release workflow refuses to publish when the signing credentials are incomplete, and verifies every signed APK against a pinned SHA-256 certificate fingerprint.
+
+## Create the release key once
+
+Keep the generated keystore in an encrypted, backed-up secret store. Losing it prevents future APK updates from being installed over existing releases.
+
+```bash
+keytool -genkeypair \
+  -keystore subnetdesk-release.jks \
+  -alias subnetdesk \
+  -keyalg RSA \
+  -keysize 4096 \
+  -validity 10000
+```
+
+Do not commit the keystore or passwords. Do not generate a new key for each build.
+
+## Configure GitHub Actions
+
+Set these repository secrets:
+
+- `ANDROID_SIGNING_KEY`: Base64-encoded contents of `subnetdesk-release.jks`.
+- `ANDROID_ALIAS`: Keystore alias, for example `subnetdesk`.
+- `ANDROID_KEY_STORE_PASSWORD`: Keystore password.
+- `ANDROID_KEY_PASSWORD`: Private-key password.
+- `ANDROID_SIGNING_CERT_SHA256`: Signing certificate SHA-256 fingerprint.
+
+Generate the Base64 value:
+
+```bash
+base64 < subnetdesk-release.jks | tr -d '\n'
+```
+
+Read the pinned fingerprint:
+
+```bash
+keytool -list -v -keystore subnetdesk-release.jks -alias subnetdesk \
+  | sed -n 's/^[[:space:]]*SHA256: //p'
+```
+
+The fingerprint may contain colons and may use either letter case. The workflow normalizes it before comparison.
+
+## Rotation
+
+Do not replace the keystore or fingerprint during ordinary releases. Android treats a package signed by another certificate as a different trust identity and will reject an in-place APK update. If rotation is unavoidable, plan it through the relevant app-store signing-key upgrade process before changing these secrets.

--- a/flutter/.gitignore
+++ b/flutter/.gitignore
@@ -52,5 +52,6 @@ lib/generated_bridge.freezed.dart
 **/Runner/bridge_generated.h
 flutter_export_environment.sh
 Flutter-Generated.xcconfig
-key.jks
+*.jks
+*.keystore
 macos/rustdesk.xcodeproj/project.xcworkspace/

--- a/flutter/android/app/build.gradle
+++ b/flutter/android/app/build.gradle
@@ -118,8 +118,8 @@ android {
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
+            // Local release builds use android/key.properties. CI replaces its
+            // temporary build signature with the pinned release certificate.
             signingConfig signingConfigs.release
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules'
         }

--- a/libs/portable/src/main.rs
+++ b/libs/portable/src/main.rs
@@ -17,10 +17,14 @@ const APP_METADATA: &[u8] = include_bytes!("../app_metadata.toml");
 const APP_METADATA: &[u8] = &[];
 const APP_METADATA_CONFIG: &str = "meta.toml";
 const META_LINE_PREFIX_TIMESTAMP: &str = "timestamp = ";
-const APP_PREFIX: &str = "rustdesk";
+const APP_PREFIX: &str = "subnetdesk";
 const APPNAME_RUNTIME_ENV_KEY: &str = "RUSTDESK_APPNAME";
 #[cfg(windows)]
 const SET_FOREGROUND_WINDOW_ENV_KEY: &str = "SET_FOREGROUND_WINDOW";
+
+fn default_unpack_dir(data_local_dir: &Path) -> PathBuf {
+    data_local_dir.join(APP_PREFIX)
+}
 
 fn is_timestamp_matches(dir: &Path, ts: &mut u64) -> bool {
     let Ok(app_metadata) = std::str::from_utf8(APP_METADATA) else {
@@ -71,7 +75,7 @@ fn setup(
     } else {
         // home dir
         if let Some(dir) = dirs::data_local_dir() {
-            dir.join(APP_PREFIX)
+            default_unpack_dir(&dir)
         } else {
             eprintln!("not found data local dir");
             return None;
@@ -207,6 +211,20 @@ fn main() {
             args = vec!["--quick_support".to_owned()];
         }
         execute(exe, args, ui);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::default_unpack_dir;
+    use std::path::Path;
+
+    #[test]
+    fn default_unpack_dir_is_isolated_from_rustdesk() {
+        assert_eq!(
+            default_unpack_dir(Path::new(r"C:\Users\user\AppData\Local")),
+            Path::new(r"C:\Users\user\AppData\Local").join("subnetdesk")
+        );
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -311,13 +311,11 @@ impl Client {
                 if let Some(expected) = expected_fingerprint.as_ref() {
                     if !identity.fingerprint.eq_ignore_ascii_case(expected) {
                         log::warn!(
-                            "Ignoring LAN endpoint {} because it belongs to fingerprint {}, expected {}",
+                            "LAN endpoint {} presented fingerprint {}, expected {}; requesting user confirmation",
                             endpoint,
                             identity.fingerprint,
                             expected
                         );
-                        errors.push(format!("{endpoint}: device identity did not match"));
-                        continue;
                     }
                 }
 


### PR DESCRIPTION
## Summary

- let LAN fingerprint mismatches reach the existing explicit trust-confirmation flow
- isolate Windows portable extraction under the SubnetDesk directory
- refuse Android release publication without the fixed signing identity and verify the APK certificate fingerprint

## Validation

- `cargo test -p rustdesk-portable-packer default_unpack_dir_is_isolated_from_rustdesk`
- `rustfmt --edition 2021 --check src/client.rs libs/portable/src/main.rs`
- workflow YAML parse
- LAN-only and SubnetDesk branding source gates
- Android signing contract check
- confirmed all five Android signing repository secrets are configured