### PR TITLE
fix(ci): keep unsigned releases compatible

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -2270,19 +2270,24 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Validate update signing configuration
+      - name: Detect update signing configuration
+        id: update_signing
         shell: bash
         run: |
           if [[ -z "$SUBNETDESK_UPDATE_PUBLIC_KEY" || -z "$UPDATE_SIGNING_KEY_B64" ]]; then
-            echo "Stable releases require SUBNETDESK_UPDATE_PUBLIC_KEY and SUBNETDESK_UPDATE_SIGNING_KEY_B64." >&2
-            exit 1
+            echo "::notice::Skipping signed update manifest because update signing keys are not configured."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           if [[ "$SIGN_BASE_URL" == "-2" || -z "$MACOS_P12_BASE64" ]]; then
-            echo "Automatic-update assets must be code signed on Windows and macOS." >&2
-            exit 1
+            echo "::notice::Skipping signed update manifest because Windows or macOS package signing is not configured."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
 
       - name: Download desktop release assets
+        if: steps.update_signing.outputs.enabled == 'true'
         shell: bash
         run: |
           mkdir update-assets
@@ -2296,6 +2301,7 @@ jobs:
             --pattern "subnetdesk-${VERSION}-aarch64.dmg"
 
       - name: Generate and sign update manifest
+        if: steps.update_signing.outputs.enabled == 'true'
         shell: bash
         run: |
           python3 scripts/generate_update_manifest.py \
@@ -2322,6 +2328,7 @@ jobs:
           xxd -p -c 128 "$signature_bin" > update-stable.json.sig
 
       - name: Upload signed update manifest
+        if: steps.update_signing.outputs.enabled == 'true'
         shell: bash
         run: |
           gh release upload "$TAG_NAME" \

--- a/.github/workflows/subnetdesk-preflight.yml
+++ b/.github/workflows/subnetdesk-preflight.yml
@@ -47,6 +47,9 @@ jobs:
           grep -Fq 'flutter precache --linux --force' .github/workflows/flutter-build.yml
           ! grep -Fq 'flutter-elinux' .github/workflows/flutter-build.yml
           grep -Fq "features.append('software-update')" build.py
+          grep -Fq 'id: update_signing' .github/workflows/flutter-build.yml
+          grep -Fq "if: steps.update_signing.outputs.enabled == 'true'" .github/workflows/flutter-build.yml
+          grep -Fq 'Skipping signed update manifest' .github/workflows/flutter-build.yml
           sed -n '/^  build-for-windows-flutter:/,/^  build-for-windows-sciter:/p' .github/workflows/flutter-build.yml | grep -Fq 'toolchain: ${{ env.RUST_VERSION }}'
           ! sed -n '/^  build-for-windows-flutter:/,/^  build-for-windows-sciter:/p' .github/workflows/flutter-build.yml | grep -Fq 'toolchain: ${{ env.SCITER_RUST_VERSION }}'
           for artifact in \

--- a/docs/automatic-updates.md
+++ b/docs/automatic-updates.md
@@ -32,15 +32,18 @@ trusting future manifests. Do not commit it to this repository.
 
 `SUBNETDESK_UPDATE_PUBLIC_KEY` is embedded into release builds. A build without
 that value remains functional but reports that automatic updates are not
-configured. Stable release publication fails when the private signing key is
-missing.
+configured. Stable releases without the update-signing or desktop
+code-signing secrets still publish their normal installers, but skip
+`update-stable.json` and in-app update delivery.
 
 The desktop build enables the Cargo `software-update` feature through
 `build.py --flutter` and `flutter/run.sh`. Mobile builds intentionally omit it.
 
 ## Release flow
 
-After all Windows and macOS assets have been uploaded, the release workflow:
+When all update and desktop code-signing secrets are configured, the release
+workflow runs these additional steps after the Windows and macOS assets have
+been uploaded:
 
 1. Downloads the release's MSI, EXE, and DMG assets.
 2. Calculates their sizes and SHA-256 hashes.
@@ -52,10 +55,12 @@ The signature file contains the raw 64-byte Ed25519 signature encoded as hex.
 Clients also verify Authenticode on Windows and code signing/Gatekeeper on
 macOS before starting an installer.
 
-Stable update publication therefore also requires the repository's existing
+Signed update-manifest publication therefore also requires the repository's
 Windows signing service secrets and macOS Developer ID/notarization secrets.
-Unsigned local builds can exercise the UI and manifest checks, but they cannot
-install a release package through the automatic updater.
+Without them, the regular release remains available through GitHub Releases,
+while in-app update delivery stays disabled. Unsigned local builds can exercise
+the UI and manifest checks, but they cannot install a release package through
+the automatic updater.
 
 ## Custom update origin
 


### PR DESCRIPTION
Stable releases historically publish without Windows, macOS, or update-signing secrets. Keep that behavior by skipping only the signed in-app update manifest when those credentials are unavailable. Normal GitHub Release installers continue to publish, while fully signed environments still generate update-stable.json.