### PR TITLE
fix(ci): parse Android 37 signing output

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -1174,8 +1174,7 @@ jobs:
             exit 1
           fi
           actual=$("$ANDROID_HOME/build-tools/$ANDROID_SIGN_TOOL_VERSION/apksigner" verify --print-certs "$SIGNED_APK" \
-            | sed -n 's/^Signer #1 certificate SHA-256 digest: //p' \
-            | head -n 1 \
+            | bash scripts/extract_android_cert_sha256.sh \
             | tr '[:lower:]' '[:upper:]' \
             | tr -d ': ')
           if [ "$actual" != "$expected" ]; then
@@ -1389,8 +1388,7 @@ jobs:
             exit 1
           fi
           actual=$("$ANDROID_HOME/build-tools/$ANDROID_SIGN_TOOL_VERSION/apksigner" verify --print-certs "$SIGNED_APK" \
-            | sed -n 's/^Signer #1 certificate SHA-256 digest: //p' \
-            | head -n 1 \
+            | bash scripts/extract_android_cert_sha256.sh \
             | tr '[:lower:]' '[:upper:]' \
             | tr -d ': ')
           if [ "$actual" != "$expected" ]; then

--- a/.github/workflows/subnetdesk-preflight.yml
+++ b/.github/workflows/subnetdesk-preflight.yml
@@ -67,7 +67,16 @@ jobs:
         run: |
           grep -Fq 'ANDROID_SIGNING_CERT_SHA256' .github/workflows/flutter-build.yml
           grep -Fq 'Verify fixed Android signing certificate' .github/workflows/flutter-build.yml
+          grep -Fq 'scripts/extract_android_cert_sha256.sh' .github/workflows/flutter-build.yml
           ! grep -Fq 'Publish unsigned apk package' .github/workflows/flutter-build.yml
+          expected=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          for output in \
+            "Signer #1 certificate SHA-256 digest: $expected" \
+            "V2 Signer: certificate SHA-256 digest: $expected"
+          do
+            actual=$(printf '%s\n' "$output" | bash scripts/extract_android_cert_sha256.sh)
+            test "$actual" = "$expected"
+          done
 
       - name: Check release upload retry contract
         run: bash scripts/check_release_upload_retry.sh

--- a/scripts/extract_android_cert_sha256.sh
+++ b/scripts/extract_android_cert_sha256.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sed -n -E \
+  's/^.*certificate SHA-256 digest:[[:space:]]*([0-9A-Fa-f]{64})[[:space:]]*$/\1/p' \
+  | head -n 1


### PR DESCRIPTION
Android Build Tools 37 labels certificate output as `V2 Signer` instead of `Signer #1`. Extract the SHA-256 digest independently of the signer label and cover both formats in preflight checks. This fixes the failed v1.3.0 Android release jobs without changing the pinned certificate.